### PR TITLE
V0.4.1

### DIFF
--- a/src/main/antlr/ShardScriptLexer.g4
+++ b/src/main/antlr/ShardScriptLexer.g4
@@ -39,7 +39,7 @@ LAMBDA: 'lambda';
 MUTABLE: 'mutable';
 OBJECT: 'object';
 RECORD: 'record';
-SHARD: 'shard';
+SCRIPT: 'script';
 TO: 'to';
 TRANSIENT: 'transient';
 VAL: 'val';

--- a/src/main/antlr/ShardScriptParser.g4
+++ b/src/main/antlr/ShardScriptParser.g4
@@ -3,15 +3,15 @@ parser grammar ShardScriptParser;
 options { tokenVocab=ShardScriptLexer; }
 
 file
-    :   (transientShard? | (shardStat importStat*)) stat+ EOF
+    :   (transientScript? | (scriptStat importStat*)) stat+ EOF
     ;
 
-transientShard
-    :   TRANSIENT SHARD importIdSeq
+transientScript
+    :   TRANSIENT SCRIPT importIdSeq
     ;
 
-shardStat
-    :   SHARD importIdSeq
+scriptStat
+    :   SCRIPT importIdSeq
     ;
 
 importStat

--- a/src/main/antlr/ShardScriptParser.g4
+++ b/src/main/antlr/ShardScriptParser.g4
@@ -157,16 +157,11 @@ ofType
     ;
 
 typeExpr
-    :   LPAREN params=restrictedTypeExprSeq RPAREN ARROW ret=restrictedTypeExpr # MultiParamFunctionType
-    |   LPAREN RPAREN ARROW ret=restrictedTypeExpr                              # NoParamFunctionType
-    |   input=restrictedTypeExpr ARROW ret=restrictedTypeExpr                   # OneParamFunctionType
-    |   id=typePath params=restrictedTypeExprParams                             # ParameterizedType
-    |   id=typePath                                                             # GroundType
-    ;
-
-typePath
-    :   IDENTIFIER (DOT IDENTIFIER)+        # MultiTypePath
-    |   IDENTIFIER                          # SingleTypePath
+    :   LPAREN params=restrictedTypeExprSeq RPAREN ARROW ret=restrictedTypeExpr     # MultiParamFunctionType
+    |   LPAREN RPAREN ARROW ret=restrictedTypeExpr                                  # NoParamFunctionType
+    |   input=restrictedTypeExpr ARROW ret=restrictedTypeExpr                       # OneParamFunctionType
+    |   id=IDENTIFIER params=restrictedTypeExprParams                               # ParameterizedType
+    |   id=IDENTIFIER                                                               # GroundType
     ;
 
 restrictedOfType
@@ -174,8 +169,8 @@ restrictedOfType
     ;
 
 restrictedTypeExpr
-    :   id=typePath params=restrictedTypeExprParams         # RestrictedParameterizedType
-    |   id=typePath                                         # RestrictedGroundType
+    :   id=IDENTIFIER params=restrictedTypeExprParams         # RestrictedParameterizedType
+    |   id=IDENTIFIER                                         # RestrictedGroundType
     ;
 
 restrictedTypeExprParams

--- a/src/main/kotlin/org/shardscript/composition/ImportsParseTreeListener.kt
+++ b/src/main/kotlin/org/shardscript/composition/ImportsParseTreeListener.kt
@@ -14,12 +14,12 @@ internal class ImportsParseTreeListener(val errors: LanguageErrors) :
     private val accumulatedImports: MutableMap<List<String>, SourceContext> = HashMap()
     private var scriptType: ScriptType = PureTransient
 
-    override fun enterTransientShard(ctx: ShardScriptParser.TransientShardContext) {
+    override fun enterTransientScript(ctx: ShardScriptParser.TransientScriptContext) {
         val nameParts = ctx.importIdSeq().IDENTIFIER().map { it.symbol.text }
         scriptType = TransientShard(nameParts)
     }
 
-    override fun enterShardStat(ctx: ShardScriptParser.ShardStatContext) {
+    override fun enterScriptStat(ctx: ShardScriptParser.ScriptStatContext) {
         val nameParts = ctx.importIdSeq().IDENTIFIER().map { it.symbol.text }
         scriptType = NamedShard(nameParts)
     }

--- a/src/main/kotlin/org/shardscript/composition/Parsing.kt
+++ b/src/main/kotlin/org/shardscript/composition/Parsing.kt
@@ -32,8 +32,7 @@ internal fun rewriteAsGroundApply(
     gid: Identifier,
     sourceContext: SourceContext
 ): GroundApplyAst {
-    val res = GroundApplyAst(gid, args)
-    res.ctx = sourceContext
+    val res = GroundApplyAst(sourceContext, gid, args)
     return res
 }
 
@@ -43,8 +42,7 @@ internal fun rewriteAsDotApply(
     op: BinaryOperator,
     sourceContext: SourceContext
 ): DotApplyAst {
-    val res = DotApplyAst(left, Identifier(op.idStr), args)
-    res.ctx = sourceContext
+    val res = DotApplyAst(sourceContext, left, Identifier(NotInSource, op.idStr), args)
     return res
 }
 
@@ -54,8 +52,7 @@ internal fun rewriteAsDotApply(
     collectionMethod: CollectionMethods,
     sourceContext: SourceContext
 ): DotApplyAst {
-    val res = DotApplyAst(left, Identifier(collectionMethod.idStr), args)
-    res.ctx = sourceContext
+    val res = DotApplyAst(sourceContext, left, Identifier(NotInSource, collectionMethod.idStr), args)
     return res
 }
 

--- a/src/main/kotlin/org/shardscript/composition/TypeLiteralParseTreeVisitor.kt
+++ b/src/main/kotlin/org/shardscript/composition/TypeLiteralParseTreeVisitor.kt
@@ -5,29 +5,15 @@ import org.shardscript.grammar.ShardScriptParserBaseVisitor
 import org.shardscript.semantics.core.*
 
 internal class TypeLiteralParseTreeVisitor(private val fileName: String) : ShardScriptParserBaseVisitor<Signifier>() {
-    override fun visitMultiTypePath(ctx: ShardScriptParser.MultiTypePathContext): Signifier {
-        val res = PathSignifier(ctx.IDENTIFIER().map {
-            val gid = Identifier(it.text)
-            gid.ctx = createContext(fileName, it.symbol)
-            gid
-        })
-        res.ctx = createContext(fileName, ctx.start)
-        return res
-    }
-
-    override fun visitSingleTypePath(ctx: ShardScriptParser.SingleTypePathContext): Signifier {
+    override fun visitGroundType(ctx: ShardScriptParser.GroundTypeContext): Signifier {
         val res = Identifier(ctx.IDENTIFIER().text.toString())
         res.ctx = createContext(fileName, ctx.IDENTIFIER().symbol)
         return res
     }
 
-    override fun visitGroundType(ctx: ShardScriptParser.GroundTypeContext): Signifier {
-        return visit(ctx.id)
-    }
-
     override fun visitParameterizedType(ctx: ShardScriptParser.ParameterizedTypeContext): Signifier {
-        val tti = visit(ctx.id) as TerminalTextSignifier
-        tti.ctx = createContext(fileName, ctx.id.start)
+        val tti = Identifier(ctx.IDENTIFIER().text.toString())
+        tti.ctx = createContext(fileName, ctx.start)
 
         val args: MutableList<Signifier> = ArrayList()
         ctx.params.restrictedTypeExprOrLiteral().forEach {
@@ -41,12 +27,14 @@ internal class TypeLiteralParseTreeVisitor(private val fileName: String) : Shard
     }
 
     override fun visitRestrictedGroundType(ctx: ShardScriptParser.RestrictedGroundTypeContext): Signifier {
-        return visit(ctx.id)
+        val res = Identifier(ctx.IDENTIFIER().text.toString())
+        res.ctx = createContext(fileName, ctx.IDENTIFIER().symbol)
+        return res
     }
 
     override fun visitRestrictedParameterizedType(ctx: ShardScriptParser.RestrictedParameterizedTypeContext): Signifier {
-        val tti = visit(ctx.id) as TerminalTextSignifier
-        tti.ctx = createContext(fileName, ctx.id.start)
+        val tti = Identifier(ctx.IDENTIFIER().text.toString())
+        tti.ctx = createContext(fileName, ctx.start)
 
         val args: MutableList<Signifier> = ArrayList()
         ctx.params.restrictedTypeExprOrLiteral().forEach {

--- a/src/main/kotlin/org/shardscript/composition/TypeLiteralParseTreeVisitor.kt
+++ b/src/main/kotlin/org/shardscript/composition/TypeLiteralParseTreeVisitor.kt
@@ -6,14 +6,12 @@ import org.shardscript.semantics.core.*
 
 internal class TypeLiteralParseTreeVisitor(private val fileName: String) : ShardScriptParserBaseVisitor<Signifier>() {
     override fun visitGroundType(ctx: ShardScriptParser.GroundTypeContext): Signifier {
-        val res = Identifier(ctx.IDENTIFIER().text.toString())
-        res.ctx = createContext(fileName, ctx.IDENTIFIER().symbol)
+        val res = Identifier(createContext(fileName, ctx.IDENTIFIER().symbol), ctx.IDENTIFIER().text.toString())
         return res
     }
 
     override fun visitParameterizedType(ctx: ShardScriptParser.ParameterizedTypeContext): Signifier {
-        val tti = Identifier(ctx.IDENTIFIER().text.toString())
-        tti.ctx = createContext(fileName, ctx.start)
+        val tti = Identifier(createContext(fileName, ctx.start), ctx.IDENTIFIER().text.toString())
 
         val args: MutableList<Signifier> = ArrayList()
         ctx.params.restrictedTypeExprOrLiteral().forEach {
@@ -21,20 +19,17 @@ internal class TypeLiteralParseTreeVisitor(private val fileName: String) : Shard
             args.add(param)
         }
 
-        val res = ParameterizedSignifier(tti, args)
-        res.ctx = createContext(fileName, ctx.start)
+        val res = ParameterizedSignifier(createContext(fileName, ctx.start), tti, args)
         return res
     }
 
     override fun visitRestrictedGroundType(ctx: ShardScriptParser.RestrictedGroundTypeContext): Signifier {
-        val res = Identifier(ctx.IDENTIFIER().text.toString())
-        res.ctx = createContext(fileName, ctx.IDENTIFIER().symbol)
+        val res = Identifier(createContext(fileName, ctx.IDENTIFIER().symbol), ctx.IDENTIFIER().text.toString())
         return res
     }
 
     override fun visitRestrictedParameterizedType(ctx: ShardScriptParser.RestrictedParameterizedTypeContext): Signifier {
-        val tti = Identifier(ctx.IDENTIFIER().text.toString())
-        tti.ctx = createContext(fileName, ctx.start)
+        val tti = Identifier(createContext(fileName, ctx.start), ctx.IDENTIFIER().text.toString())
 
         val args: MutableList<Signifier> = ArrayList()
         ctx.params.restrictedTypeExprOrLiteral().forEach {
@@ -42,14 +37,12 @@ internal class TypeLiteralParseTreeVisitor(private val fileName: String) : Shard
             args.add(param)
         }
 
-        val res = ParameterizedSignifier(tti, args)
-        res.ctx = createContext(fileName, ctx.start)
+        val res = ParameterizedSignifier(createContext(fileName, ctx.start), tti, args)
         return res
     }
 
     override fun visitFinLiteral(ctx: ShardScriptParser.FinLiteralContext): Signifier {
-        val res = FinLiteral(ctx.magnitude.text.toLong())
-        res.ctx = createContext(fileName, ctx.magnitude)
+        val res = FinLiteral(createContext(fileName, ctx.magnitude), ctx.magnitude.text.toLong())
         return res
     }
 
@@ -66,8 +59,7 @@ internal class TypeLiteralParseTreeVisitor(private val fileName: String) : Shard
             params.add(param)
         }
 
-        val res = FunctionTypeLiteral(params, ret)
-        res.ctx = createContext(fileName, ctx.start)
+        val res = FunctionTypeLiteral(createContext(fileName, ctx.start), params, ret)
         return res
     }
 
@@ -75,8 +67,7 @@ internal class TypeLiteralParseTreeVisitor(private val fileName: String) : Shard
         val params: MutableList<Signifier> = ArrayList()
         val ret = visit(ctx.ret)
 
-        val res = FunctionTypeLiteral(params, ret)
-        res.ctx = createContext(fileName, ctx.start)
+        val res = FunctionTypeLiteral(createContext(fileName, ctx.start), params, ret)
         return res
     }
 
@@ -87,8 +78,7 @@ internal class TypeLiteralParseTreeVisitor(private val fileName: String) : Shard
         val input = visit(ctx.input)
         params.add(input)
 
-        val res = FunctionTypeLiteral(params, ret)
-        res.ctx = createContext(fileName, ctx.start)
+        val res = FunctionTypeLiteral(createContext(fileName, ctx.start), params, ret)
         return res
     }
 }

--- a/src/main/kotlin/org/shardscript/semantics/core/Ast.kt
+++ b/src/main/kotlin/org/shardscript/semantics/core/Ast.kt
@@ -11,7 +11,6 @@ sealed class Ast : LanguageElement {
         type = filterValidTypes(ctx, errors, t)
     }
 
-    override var ctx: SourceContext = NotInSource
     lateinit var scope: Scope<Symbol>
     lateinit var costExpression: CostExpression
     var approach: Boolean = true
@@ -32,7 +31,7 @@ sealed class ApplyAst : SymbolRefAst() {
     abstract val args: List<Ast>
 }
 
-data class IntLiteralAst(val canonicalForm: Int) : Ast() {
+data class IntLiteralAst(override val ctx: SourceContext, val canonicalForm: Int) : Ast() {
     override fun <R> accept(visitor: AstVisitor<R>): R =
         visitor.visit(this)
 
@@ -40,7 +39,7 @@ data class IntLiteralAst(val canonicalForm: Int) : Ast() {
         visitor.visit(this, param)
 }
 
-data class DecimalLiteralAst(val canonicalForm: BigDecimal) : Ast() {
+data class DecimalLiteralAst(override val ctx: SourceContext, val canonicalForm: BigDecimal) : Ast() {
     override fun <R> accept(visitor: AstVisitor<R>): R =
         visitor.visit(this)
 
@@ -48,7 +47,7 @@ data class DecimalLiteralAst(val canonicalForm: BigDecimal) : Ast() {
         visitor.visit(this, param)
 }
 
-data class BooleanLiteralAst(val canonicalForm: Boolean) : Ast() {
+data class BooleanLiteralAst(override val ctx: SourceContext, val canonicalForm: Boolean) : Ast() {
     override fun <R> accept(visitor: AstVisitor<R>): R =
         visitor.visit(this)
 
@@ -56,7 +55,7 @@ data class BooleanLiteralAst(val canonicalForm: Boolean) : Ast() {
         visitor.visit(this, param)
 }
 
-data class CharLiteralAst(val canonicalForm: Char) : Ast() {
+data class CharLiteralAst(override val ctx: SourceContext, val canonicalForm: Char) : Ast() {
     override fun <R> accept(visitor: AstVisitor<R>): R =
         visitor.visit(this)
 
@@ -64,7 +63,7 @@ data class CharLiteralAst(val canonicalForm: Char) : Ast() {
         visitor.visit(this, param)
 }
 
-data class StringLiteralAst(val canonicalForm: String) : Ast() {
+data class StringLiteralAst(override val ctx: SourceContext, val canonicalForm: String) : Ast() {
     override fun <R> accept(visitor: AstVisitor<R>): R =
         visitor.visit(this)
 
@@ -72,7 +71,7 @@ data class StringLiteralAst(val canonicalForm: String) : Ast() {
         visitor.visit(this, param)
 }
 
-data class StringInterpolationAst(val components: List<Ast>) : Ast() {
+data class StringInterpolationAst(override val ctx: SourceContext, val components: List<Ast>) : Ast() {
     override fun <R> accept(visitor: AstVisitor<R>): R =
         visitor.visit(this)
 
@@ -81,6 +80,7 @@ data class StringInterpolationAst(val components: List<Ast>) : Ast() {
 }
 
 data class LetAst(
+    override val ctx: SourceContext,
     val identifier: Identifier,
     val ofType: Signifier,
     val rhs: Ast,
@@ -95,7 +95,7 @@ data class LetAst(
         visitor.visit(this, param)
 }
 
-data class RefAst(val identifier: Identifier) : SymbolRefAst() {
+data class RefAst(override val ctx: SourceContext, val identifier: Identifier) : SymbolRefAst() {
     override fun <R> accept(visitor: AstVisitor<R>): R =
         visitor.visit(this)
 
@@ -103,7 +103,7 @@ data class RefAst(val identifier: Identifier) : SymbolRefAst() {
         visitor.visit(this, param)
 }
 
-data class FileAst(val lines: List<Ast>) : Ast() {
+data class FileAst(override val ctx: SourceContext, val lines: List<Ast>) : Ast() {
     override fun <R> accept(visitor: AstVisitor<R>): R =
         visitor.visit(this)
 
@@ -111,7 +111,7 @@ data class FileAst(val lines: List<Ast>) : Ast() {
         visitor.visit(this, param)
 }
 
-data class BlockAst(val lines: MutableList<Ast>) : Ast() {
+data class BlockAst(override val ctx: SourceContext, val lines: MutableList<Ast>) : Ast() {
     override fun <R> accept(visitor: AstVisitor<R>): R =
         visitor.visit(this)
 
@@ -120,6 +120,7 @@ data class BlockAst(val lines: MutableList<Ast>) : Ast() {
 }
 
 data class FunctionAst(
+    override val ctx: SourceContext,
     val identifier: Identifier,
     val typeParams: List<TypeParameterDefinition>,
     val formalParams: List<Binder>,
@@ -134,6 +135,7 @@ data class FunctionAst(
 }
 
 data class LambdaAst(
+    override val ctx: SourceContext,
     val formalParams: List<Binder>,
     val body: Ast
 ) : Ast() {
@@ -145,6 +147,7 @@ data class LambdaAst(
 }
 
 data class RecordDefinitionAst(
+    override val ctx: SourceContext,
     val identifier: Identifier,
     val typeParams: List<TypeParameterDefinition>,
     val fields: List<FieldDef>
@@ -157,6 +160,7 @@ data class RecordDefinitionAst(
 }
 
 data class ObjectDefinitionAst(
+    override val ctx: SourceContext,
     val identifier: Identifier
 ) : DefinitionAst() {
     override fun <R> accept(visitor: AstVisitor<R>): R =
@@ -167,6 +171,7 @@ data class ObjectDefinitionAst(
 }
 
 data class DotAst(
+    override val ctx: SourceContext,
     val lhs: Ast,
     val identifier: Identifier
 ) : SymbolRefAst() {
@@ -178,6 +183,7 @@ data class DotAst(
 }
 
 data class GroundApplyAst(
+    override val ctx: SourceContext,
     val signifier: Signifier,
     override val args: List<Ast>
 ) : ApplyAst() {
@@ -191,6 +197,7 @@ data class GroundApplyAst(
 }
 
 data class DotApplyAst(
+    override val ctx: SourceContext,
     val lhs: Ast,
     val signifier: Signifier,
     override val args: List<Ast>
@@ -205,6 +212,7 @@ data class DotApplyAst(
 }
 
 data class ForEachAst(
+    override val ctx: SourceContext,
     val identifier: Identifier,
     val ofType: Signifier,
     val source: Ast,
@@ -222,6 +230,7 @@ data class ForEachAst(
 }
 
 data class AssignAst(
+    override val ctx: SourceContext,
     val identifier: Identifier,
     val rhs: Ast
 ) : SymbolRefAst() {
@@ -233,6 +242,7 @@ data class AssignAst(
 }
 
 data class DotAssignAst(
+    override val ctx: SourceContext,
     val lhs: Ast,
     val identifier: Identifier,
     val rhs: Ast
@@ -245,6 +255,7 @@ data class DotAssignAst(
 }
 
 data class IfAst(
+    override val ctx: SourceContext,
     val condition: Ast,
     val trueBranch: Ast,
     val falseBranch: Ast
@@ -257,6 +268,7 @@ data class IfAst(
 }
 
 data class AsAst(
+    override val ctx: SourceContext,
     val lhs: Ast,
     val signifier: Signifier
 ) : Ast() {
@@ -268,6 +280,7 @@ data class AsAst(
 }
 
 data class IsAst(
+    override val ctx: SourceContext,
     val lhs: Ast,
     val signifier: Signifier
 ) : Ast() {

--- a/src/main/kotlin/org/shardscript/semantics/core/Constructs.kt
+++ b/src/main/kotlin/org/shardscript/semantics/core/Constructs.kt
@@ -1,7 +1,7 @@
 package org.shardscript.semantics.core
 
 interface LanguageElement {
-    var ctx: SourceContext
+    val ctx: SourceContext
 }
 
 data class Binder(val identifier: Identifier, val ofType: Signifier) {
@@ -24,14 +24,14 @@ sealed class CaseBranch : LanguageElement {
 }
 
 data class CoproductBranch(
-    override var ctx: SourceContext,
+    override val ctx: SourceContext,
     val identifier: Identifier,
     override val body: BlockAst
 ) : CaseBranch() {
     lateinit var path: List<String>
 }
 
-data class ElseBranch(override var ctx: SourceContext, override val body: BlockAst) : CaseBranch()
+data class ElseBranch(override val ctx: SourceContext, override val body: BlockAst) : CaseBranch()
 
 interface SingleTypeInstantiation {
     fun apply(

--- a/src/main/kotlin/org/shardscript/semantics/core/Scope.kt
+++ b/src/main/kotlin/org/shardscript/semantics/core/Scope.kt
@@ -29,9 +29,9 @@ object NullSymbolTable : Scope<Symbol> {
 }
 
 class SymbolTable(private val parent: Scope<Symbol>) : Scope<Symbol> {
-    private val identifierTable: MutableMap<Identifier, Symbol> = HashMap()
+    private val identifierTable: MutableMap<String, Symbol> = HashMap()
 
-    fun toMap(): Map<Identifier, Symbol> = identifierTable.toMap()
+    fun toMap(): Map<String, Symbol> = identifierTable.toMap()
 
     private fun toType(signifier: Signifier, symbol: Symbol): Type {
         if (symbol is Type) {
@@ -42,16 +42,16 @@ class SymbolTable(private val parent: Scope<Symbol>) : Scope<Symbol> {
     }
 
     override fun define(identifier: Identifier, definition: Symbol) {
-        if (identifierTable.containsKey(identifier)) {
+        if (identifierTable.containsKey(identifier.name)) {
             langThrow(identifier.ctx, IdentifierAlreadyExists(identifier))
         } else {
-            identifierTable[identifier] = definition
+            identifierTable[identifier.name] = definition
         }
     }
 
     override fun exists(signifier: Signifier): Boolean =
         when (signifier) {
-            is Identifier -> identifierTable.containsKey(signifier) || parent.exists(signifier)
+            is Identifier -> identifierTable.containsKey(signifier.name) || parent.exists(signifier)
             is FunctionTypeLiteral -> signifier.formalParamTypes.all { exists(it) } && exists(signifier.returnType)
             is ParameterizedSignifier -> exists(signifier.tti) && signifier.args.all { exists(it) }
             is ImplicitTypeLiteral -> false
@@ -60,7 +60,7 @@ class SymbolTable(private val parent: Scope<Symbol>) : Scope<Symbol> {
 
     override fun existsHere(signifier: Signifier): Boolean =
         when (signifier) {
-            is Identifier -> identifierTable.containsKey(signifier)
+            is Identifier -> identifierTable.containsKey(signifier.name)
             is FunctionTypeLiteral -> signifier.formalParamTypes.all { exists(it) } && exists(signifier.returnType)
             is ParameterizedSignifier -> existsHere(signifier.tti) && signifier.args.all { exists(it) }
             is ImplicitTypeLiteral -> false
@@ -70,8 +70,8 @@ class SymbolTable(private val parent: Scope<Symbol>) : Scope<Symbol> {
     override fun fetch(signifier: Signifier): Symbol =
         when (signifier) {
             is Identifier -> {
-                if (identifierTable.containsKey(signifier)) {
-                    identifierTable[signifier]!!
+                if (identifierTable.containsKey(signifier.name)) {
+                    identifierTable[signifier.name]!!
                 } else {
                     parent.fetch(signifier)
                 }
@@ -116,8 +116,8 @@ class SymbolTable(private val parent: Scope<Symbol>) : Scope<Symbol> {
     override fun fetchHere(signifier: Signifier): Symbol =
         when (signifier) {
             is Identifier -> {
-                if (identifierTable.containsKey(signifier)) {
-                    identifierTable[signifier]!!
+                if (identifierTable.containsKey(signifier.name)) {
+                    identifierTable[signifier.name]!!
                 } else {
                     langThrow(signifier.ctx, IdentifierNotFound(signifier))
                 }

--- a/src/main/kotlin/org/shardscript/semantics/core/Scope.kt
+++ b/src/main/kotlin/org/shardscript/semantics/core/Scope.kt
@@ -52,26 +52,6 @@ class SymbolTable(private val parent: Scope<Symbol>) : Scope<Symbol> {
     override fun exists(signifier: Signifier): Boolean =
         when (signifier) {
             is Identifier -> identifierTable.containsKey(signifier) || parent.exists(signifier)
-            is PathSignifier -> {
-                val first = signifier.elements.first()
-                if (identifierTable.containsKey(first)) {
-                    val pathRes = identifierTable[first]!!
-                    if (pathRes is Namespace) {
-                        val rest = signifier.elements.toMutableList()
-                        rest.removeAt(0)
-                        val next = if (rest.size == 1) {
-                            rest.first()
-                        } else {
-                            PathSignifier(rest.toList())
-                        }
-                        pathRes.existsHere(next) || parent.exists(signifier)
-                    } else {
-                        parent.exists(signifier)
-                    }
-                } else {
-                    parent.exists(signifier)
-                }
-            }
             is FunctionTypeLiteral -> signifier.formalParamTypes.all { exists(it) } && exists(signifier.returnType)
             is ParameterizedSignifier -> exists(signifier.tti) && signifier.args.all { exists(it) }
             is ImplicitTypeLiteral -> false
@@ -81,26 +61,6 @@ class SymbolTable(private val parent: Scope<Symbol>) : Scope<Symbol> {
     override fun existsHere(signifier: Signifier): Boolean =
         when (signifier) {
             is Identifier -> identifierTable.containsKey(signifier)
-            is PathSignifier -> {
-                val first = signifier.elements.first()
-                if (identifierTable.containsKey(first)) {
-                    val pathRes = identifierTable[first]!!
-                    if (pathRes is Namespace) {
-                        val rest = signifier.elements.toMutableList()
-                        rest.removeAt(0)
-                        val next = if (rest.size == 1) {
-                            rest.first()
-                        } else {
-                            PathSignifier(rest.toList())
-                        }
-                        pathRes.existsHere(next)
-                    } else {
-                        false
-                    }
-                } else {
-                    false
-                }
-            }
             is FunctionTypeLiteral -> signifier.formalParamTypes.all { exists(it) } && exists(signifier.returnType)
             is ParameterizedSignifier -> existsHere(signifier.tti) && signifier.args.all { exists(it) }
             is ImplicitTypeLiteral -> false
@@ -112,26 +72,6 @@ class SymbolTable(private val parent: Scope<Symbol>) : Scope<Symbol> {
             is Identifier -> {
                 if (identifierTable.containsKey(signifier)) {
                     identifierTable[signifier]!!
-                } else {
-                    parent.fetch(signifier)
-                }
-            }
-            is PathSignifier -> {
-                val first = signifier.elements.first()
-                if (identifierTable.containsKey(first)) {
-                    val pathRes = identifierTable[first]!!
-                    if (pathRes is Namespace) {
-                        val rest = signifier.elements.toMutableList()
-                        rest.removeAt(0)
-                        val next = if (rest.size == 1) {
-                            rest.first()
-                        } else {
-                            PathSignifier(rest.toList())
-                        }
-                        pathRes.fetchHere(next)
-                    } else {
-                        parent.fetch(signifier)
-                    }
                 } else {
                     parent.fetch(signifier)
                 }
@@ -178,26 +118,6 @@ class SymbolTable(private val parent: Scope<Symbol>) : Scope<Symbol> {
             is Identifier -> {
                 if (identifierTable.containsKey(signifier)) {
                     identifierTable[signifier]!!
-                } else {
-                    langThrow(signifier.ctx, IdentifierNotFound(signifier))
-                }
-            }
-            is PathSignifier -> {
-                val first = signifier.elements.first()
-                if (identifierTable.containsKey(first)) {
-                    val pathRes = identifierTable[first]!!
-                    if (pathRes is Namespace) {
-                        val rest = signifier.elements.toMutableList()
-                        rest.removeAt(0)
-                        val next = if (rest.size == 1) {
-                            rest.first()
-                        } else {
-                            PathSignifier(rest.toList())
-                        }
-                        pathRes.fetchHere(next)
-                    } else {
-                        langThrow(signifier.ctx, IdentifierNotFound(signifier))
-                    }
                 } else {
                     langThrow(signifier.ctx, IdentifierNotFound(signifier))
                 }

--- a/src/main/kotlin/org/shardscript/semantics/core/Signifier.kt
+++ b/src/main/kotlin/org/shardscript/semantics/core/Signifier.kt
@@ -20,13 +20,11 @@ class ImplicitTypeLiteral : TerminalSignifier() {
 }
 
 data class ParameterizedSignifier(val tti: TerminalTextSignifier, val args: List<Signifier>) : Signifier()
-data class PathSignifier(val elements: List<Identifier>) : TerminalTextSignifier()
 data class Identifier(val name: String) : TerminalTextSignifier()
 data class FinLiteral(val magnitude: Long) : TerminalSignifier()
 
 fun printIdentifier(signifier: Signifier): String =
     when (signifier) {
-        is PathSignifier -> signifier.elements.joinToString(".", transform = { it.name })
         is Identifier -> signifier.name
         is ImplicitTypeLiteral -> langThrow(TypeSystemBug)
         is FinLiteral -> signifier.magnitude.toString()
@@ -59,12 +57,8 @@ fun linearizeIdentifiers(signifiers: List<Signifier>): List<TerminalSignifier> {
                     linearizeIdentifiersAux(it)
                 }
             }
-            is PathSignifier -> {
-                res.add(signifier)
-            }
             is Identifier -> {
                 res.add(signifier)
-
             }
             is FinLiteral -> {
                 res.add(signifier)

--- a/src/main/kotlin/org/shardscript/semantics/core/Signifier.kt
+++ b/src/main/kotlin/org/shardscript/semantics/core/Signifier.kt
@@ -1,44 +1,31 @@
 package org.shardscript.semantics.core
 
-sealed class Signifier : LanguageElement {
-    override var ctx: SourceContext = NotInSource
-}
+sealed class Signifier : LanguageElement
 
 sealed class TerminalSignifier : Signifier()
 sealed class TerminalTextSignifier : TerminalSignifier()
 
 data class FunctionTypeLiteral(
+    override val ctx: SourceContext,
     val formalParamTypes: List<Signifier>,
     val returnType: Signifier
 ) : Signifier()
 
-class ImplicitTypeLiteral : TerminalSignifier() {
+class ImplicitTypeLiteral(override val ctx: SourceContext) : TerminalSignifier() {
     private object HashCodeHelper
 
     override fun equals(other: Any?): Boolean = other != null && other is ImplicitTypeLiteral
     override fun hashCode(): Int = HashCodeHelper.hashCode()
 }
 
-data class ParameterizedSignifier(val tti: TerminalTextSignifier, val args: List<Signifier>) : Signifier()
-data class Identifier(val name: String) : TerminalTextSignifier()
-data class FinLiteral(val magnitude: Long) : TerminalSignifier()
+data class ParameterizedSignifier(
+    override val ctx: SourceContext,
+    val tti: TerminalTextSignifier,
+    val args: List<Signifier>
+) : Signifier()
 
-fun printIdentifier(signifier: Signifier): String =
-    when (signifier) {
-        is Identifier -> signifier.name
-        is ImplicitTypeLiteral -> langThrow(TypeSystemBug)
-        is FinLiteral -> signifier.magnitude.toString()
-        is FunctionTypeLiteral -> "(${
-            signifier.formalParamTypes.joinToString(
-                ", ",
-                transform = { printIdentifier(it) })
-        }) -> ${printIdentifier(signifier.returnType)}"
-        is ParameterizedSignifier -> "${printIdentifier(signifier)}<${
-            signifier.args.joinToString(
-                ", ",
-                transform = { printIdentifier(it) })
-        }>"
-    }
+data class Identifier(override val ctx: SourceContext, val name: String) : TerminalTextSignifier()
+data class FinLiteral(override val ctx: SourceContext, val magnitude: Long) : TerminalSignifier()
 
 fun linearizeIdentifiers(signifiers: List<Signifier>): List<TerminalSignifier> {
     val res: MutableList<TerminalSignifier> = ArrayList()

--- a/src/main/kotlin/org/shardscript/semantics/core/StringMechanics.kt
+++ b/src/main/kotlin/org/shardscript/semantics/core/StringMechanics.kt
@@ -5,15 +5,15 @@ import org.shardscript.semantics.prelude.StringMethods
 fun isValidStringType(type: Type): Boolean =
     when (type) {
         is ObjectSymbol -> {
-            type.existsHere(Identifier(StringMethods.ToString.idStr))
+            type.existsHere(Identifier(NotInSource, StringMethods.ToString.idStr))
         }
         is BasicTypeSymbol -> {
-            type.existsHere(Identifier(StringMethods.ToString.idStr))
+            type.existsHere(Identifier(NotInSource, StringMethods.ToString.idStr))
         }
         is SymbolInstantiation -> {
             when (val parameterizedType = type.substitutionChain.originalSymbol) {
                 is ParameterizedBasicTypeSymbol -> {
-                    parameterizedType.existsHere(Identifier(StringMethods.ToString.idStr))
+                    parameterizedType.existsHere(Identifier(NotInSource, StringMethods.ToString.idStr))
                 }
                 else -> false
             }
@@ -24,15 +24,15 @@ fun isValidStringType(type: Type): Boolean =
 fun costExpressionFromValidStringType(type: Type): CostExpression {
     val member = when (type) {
         is ObjectSymbol -> {
-            type.fetchHere(Identifier(StringMethods.ToString.idStr))
+            type.fetchHere(Identifier(NotInSource, StringMethods.ToString.idStr))
         }
         is BasicTypeSymbol -> {
-            type.fetchHere(Identifier(StringMethods.ToString.idStr))
+            type.fetchHere(Identifier(NotInSource, StringMethods.ToString.idStr))
         }
         is SymbolInstantiation -> {
             when (val parameterizedType = type.substitutionChain.originalSymbol) {
                 is ParameterizedBasicTypeSymbol -> {
-                    parameterizedType.fetchHere(Identifier(StringMethods.ToString.idStr))
+                    parameterizedType.fetchHere(Identifier(NotInSource, StringMethods.ToString.idStr))
                 }
                 else -> langThrow(TypeSystemBug)
             }

--- a/src/main/kotlin/org/shardscript/semantics/core/Value.kt
+++ b/src/main/kotlin/org/shardscript/semantics/core/Value.kt
@@ -566,12 +566,12 @@ class SymbolRouterValueTable(private val prelude: PreludeTable, private val symb
 class ValueTable(private val parent: Scope<Value>) : Scope<Value> {
     data class ScopeSlot(var value: Value)
 
-    private val slotTable: MutableMap<Identifier, ScopeSlot> = HashMap()
+    private val slotTable: MutableMap<String, ScopeSlot> = HashMap()
 
     fun valuesHere() = slotTable.map { Pair(it.key, it.value.value) }.toMap()
 
     override fun define(identifier: Identifier, definition: Value) {
-        slotTable[identifier] = ScopeSlot(definition)
+        slotTable[identifier.name] = ScopeSlot(definition)
     }
 
     fun assign(identifier: Identifier, definition: Value) {
@@ -580,8 +580,8 @@ class ValueTable(private val parent: Scope<Value>) : Scope<Value> {
     }
 
     private fun fetchSlot(identifier: Identifier): ScopeSlot =
-        if (slotTable.containsKey(identifier)) {
-            slotTable[identifier]!!
+        if (slotTable.containsKey(identifier.name)) {
+            slotTable[identifier.name]!!
         } else {
             if (parent is ValueTable) {
                 parent.fetchSlot(identifier)
@@ -592,21 +592,21 @@ class ValueTable(private val parent: Scope<Value>) : Scope<Value> {
 
     override fun exists(signifier: Signifier): Boolean =
         when (signifier) {
-            is Identifier -> slotTable.containsKey(signifier) || parent.exists(signifier)
+            is Identifier -> slotTable.containsKey(signifier.name) || parent.exists(signifier)
             else -> false
         }
 
     override fun existsHere(signifier: Signifier): Boolean =
         when (signifier) {
-            is Identifier -> slotTable.containsKey(signifier)
+            is Identifier -> slotTable.containsKey(signifier.name)
             else -> false
         }
 
     override fun fetch(signifier: Signifier): Value =
         when (signifier) {
             is Identifier -> {
-                if (slotTable.containsKey(signifier)) {
-                    slotTable[signifier]!!.value
+                if (slotTable.containsKey(signifier.name)) {
+                    slotTable[signifier.name]!!.value
                 } else {
                     parent.fetch(signifier)
                 }
@@ -617,8 +617,8 @@ class ValueTable(private val parent: Scope<Value>) : Scope<Value> {
     override fun fetchHere(signifier: Signifier): Value =
         when (signifier) {
             is Identifier -> {
-                if (slotTable.containsKey(signifier)) {
-                    slotTable[signifier]!!.value
+                if (slotTable.containsKey(signifier.name)) {
+                    slotTable[signifier.name]!!.value
                 } else {
                     langThrow(signifier.ctx, IdentifierNotFound(signifier))
                 }

--- a/src/main/kotlin/org/shardscript/semantics/prelude/DecimalOpMembers.kt
+++ b/src/main/kotlin/org/shardscript/semantics/prelude/DecimalOpMembers.kt
@@ -24,7 +24,7 @@ object DecimalMathOpMembers {
     ): ParameterizedMemberPluginSymbol {
         val res = ParameterizedMemberPluginSymbol(
             decimalType,
-            Identifier(BinaryOperator.Add.idStr),
+            Identifier(NotInSource, BinaryOperator.Add.idStr),
             DualFinPluginInstantiation
         ) { t: Value, args: List<Value> ->
             (t as MathValue).evalAdd(args.first())
@@ -35,7 +35,7 @@ object DecimalMathOpMembers {
 
         val inputSubstitution = Substitution(listOf(decimalTypeParam), listOf(inputTypeArg))
         val inputType = inputSubstitution.apply(decimalType)
-        val formalParamId = Identifier("other")
+        val formalParamId = Identifier(NotInSource, "other")
         val formalParam = FunctionFormalParameterSymbol(res, formalParamId, inputType)
         res.define(formalParamId, formalParam)
         res.formalParams = listOf(formalParam)
@@ -65,7 +65,7 @@ object DecimalMathOpMembers {
     ): ParameterizedMemberPluginSymbol {
         val res = ParameterizedMemberPluginSymbol(
             decimalType,
-            Identifier(BinaryOperator.Sub.idStr),
+            Identifier(NotInSource, BinaryOperator.Sub.idStr),
             DualFinPluginInstantiation
         ) { t: Value, args: List<Value> ->
             (t as MathValue).evalSub(args.first())
@@ -76,7 +76,7 @@ object DecimalMathOpMembers {
 
         val inputSubstitution = Substitution(listOf(decimalTypeParam), listOf(inputTypeArg))
         val inputType = inputSubstitution.apply(decimalType)
-        val formalParamId = Identifier("other")
+        val formalParamId = Identifier(NotInSource, "other")
         val formalParam = FunctionFormalParameterSymbol(res, formalParamId, inputType)
         res.define(formalParamId, formalParam)
         res.formalParams = listOf(formalParam)
@@ -106,7 +106,7 @@ object DecimalMathOpMembers {
     ): ParameterizedMemberPluginSymbol {
         val res = ParameterizedMemberPluginSymbol(
             decimalType,
-            Identifier(BinaryOperator.Mul.idStr),
+            Identifier(NotInSource, BinaryOperator.Mul.idStr),
             DualFinPluginInstantiation
         ) { t: Value, args: List<Value> ->
             (t as MathValue).evalMul(args.first())
@@ -117,7 +117,7 @@ object DecimalMathOpMembers {
 
         val inputSubstitution = Substitution(listOf(decimalTypeParam), listOf(inputTypeArg))
         val inputType = inputSubstitution.apply(decimalType)
-        val formalParamId = Identifier("other")
+        val formalParamId = Identifier(NotInSource, "other")
         val formalParam = FunctionFormalParameterSymbol(res, formalParamId, inputType)
         res.define(formalParamId, formalParam)
         res.formalParams = listOf(formalParam)
@@ -147,7 +147,7 @@ object DecimalMathOpMembers {
     ): ParameterizedMemberPluginSymbol {
         val res = ParameterizedMemberPluginSymbol(
             decimalType,
-            Identifier(BinaryOperator.Div.idStr),
+            Identifier(NotInSource, BinaryOperator.Div.idStr),
             DualFinPluginInstantiation
         ) { t: Value, args: List<Value> ->
             (t as MathValue).evalDiv(args.first())
@@ -158,7 +158,7 @@ object DecimalMathOpMembers {
 
         val inputSubstitution = Substitution(listOf(decimalTypeParam), listOf(inputTypeArg))
         val inputType = inputSubstitution.apply(decimalType)
-        val formalParamId = Identifier("other")
+        val formalParamId = Identifier(NotInSource, "other")
         val formalParam = FunctionFormalParameterSymbol(res, formalParamId, inputType)
         res.define(formalParamId, formalParam)
         res.formalParams = listOf(formalParam)
@@ -183,7 +183,7 @@ object DecimalMathOpMembers {
     ): ParameterizedMemberPluginSymbol {
         val res = ParameterizedMemberPluginSymbol(
             decimalType,
-            Identifier(BinaryOperator.Mod.idStr),
+            Identifier(NotInSource, BinaryOperator.Mod.idStr),
             DualFinPluginInstantiation
         ) { t: Value, args: List<Value> ->
             (t as MathValue).evalMod(args.first())
@@ -194,7 +194,7 @@ object DecimalMathOpMembers {
 
         val inputSubstitution = Substitution(listOf(decimalTypeParam), listOf(inputTypeArg))
         val inputType = inputSubstitution.apply(decimalType)
-        val formalParamId = Identifier("other")
+        val formalParamId = Identifier(NotInSource, "other")
         val formalParam = FunctionFormalParameterSymbol(res, formalParamId, inputType)
         res.define(formalParamId, formalParam)
         res.formalParams = listOf(formalParam)
@@ -219,7 +219,7 @@ object DecimalMathOpMembers {
     ): ParameterizedMemberPluginSymbol {
         val res = ParameterizedMemberPluginSymbol(
             decimalType,
-            Identifier(UnaryOperator.Negate.idStr),
+            Identifier(NotInSource, UnaryOperator.Negate.idStr),
             SingleParentArgInstantiation
         ) { t: Value, _: List<Value> ->
             (t as MathValue).evalNegate()
@@ -254,7 +254,7 @@ object DecimalOrderOpMembers {
     ): ParameterizedMemberPluginSymbol {
         val res = ParameterizedMemberPluginSymbol(
             decimalType,
-            Identifier(BinaryOperator.GreaterThan.idStr),
+            Identifier(NotInSource, BinaryOperator.GreaterThan.idStr),
             DualFinPluginInstantiation
         ) { t: Value, args: List<Value> ->
             (t as OrderValue).evalGreaterThan(args.first())
@@ -265,7 +265,7 @@ object DecimalOrderOpMembers {
 
         val inputSubstitution = Substitution(listOf(decimalTypeParam), listOf(inputTypeArg))
         val inputType = inputSubstitution.apply(decimalType)
-        val formalParamId = Identifier("other")
+        val formalParamId = Identifier(NotInSource, "other")
         val formalParam = FunctionFormalParameterSymbol(res, formalParamId, inputType)
         res.define(formalParamId, formalParam)
         res.formalParams = listOf(formalParam)
@@ -294,7 +294,7 @@ object DecimalOrderOpMembers {
     ): ParameterizedMemberPluginSymbol {
         val res = ParameterizedMemberPluginSymbol(
             decimalType,
-            Identifier(BinaryOperator.GreaterThanEqual.idStr),
+            Identifier(NotInSource, BinaryOperator.GreaterThanEqual.idStr),
             DualFinPluginInstantiation
         ) { t: Value, args: List<Value> ->
             (t as OrderValue).evalGreaterThanOrEquals(args.first())
@@ -305,7 +305,7 @@ object DecimalOrderOpMembers {
 
         val inputSubstitution = Substitution(listOf(decimalTypeParam), listOf(inputTypeArg))
         val inputType = inputSubstitution.apply(decimalType)
-        val formalParamId = Identifier("other")
+        val formalParamId = Identifier(NotInSource, "other")
         val formalParam = FunctionFormalParameterSymbol(res, formalParamId, inputType)
         res.define(formalParamId, formalParam)
         res.formalParams = listOf(formalParam)
@@ -334,7 +334,7 @@ object DecimalOrderOpMembers {
     ): ParameterizedMemberPluginSymbol {
         val res = ParameterizedMemberPluginSymbol(
             decimalType,
-            Identifier(BinaryOperator.LessThan.idStr),
+            Identifier(NotInSource, BinaryOperator.LessThan.idStr),
             DualFinPluginInstantiation
         ) { t: Value, args: List<Value> ->
             (t as OrderValue).evalLessThan(args.first())
@@ -345,7 +345,7 @@ object DecimalOrderOpMembers {
 
         val inputSubstitution = Substitution(listOf(decimalTypeParam), listOf(inputTypeArg))
         val inputType = inputSubstitution.apply(decimalType)
-        val formalParamId = Identifier("other")
+        val formalParamId = Identifier(NotInSource, "other")
         val formalParam = FunctionFormalParameterSymbol(res, formalParamId, inputType)
         res.define(formalParamId, formalParam)
         res.formalParams = listOf(formalParam)
@@ -374,7 +374,7 @@ object DecimalOrderOpMembers {
     ): ParameterizedMemberPluginSymbol {
         val res = ParameterizedMemberPluginSymbol(
             decimalType,
-            Identifier(BinaryOperator.LessThanEqual.idStr),
+            Identifier(NotInSource, BinaryOperator.LessThanEqual.idStr),
             DualFinPluginInstantiation
         ) { t: Value, args: List<Value> ->
             (t as OrderValue).evalLessThanOrEquals(args.first())
@@ -385,7 +385,7 @@ object DecimalOrderOpMembers {
 
         val inputSubstitution = Substitution(listOf(decimalTypeParam), listOf(inputTypeArg))
         val inputType = inputSubstitution.apply(decimalType)
-        val formalParamId = Identifier("other")
+        val formalParamId = Identifier(NotInSource, "other")
         val formalParam = FunctionFormalParameterSymbol(res, formalParamId, inputType)
         res.define(formalParamId, formalParam)
         res.formalParams = listOf(formalParam)
@@ -425,7 +425,7 @@ object DecimalEqualityOpMembers {
     ): ParameterizedMemberPluginSymbol {
         val res = ParameterizedMemberPluginSymbol(
             decimalType,
-            Identifier(BinaryOperator.Equal.idStr),
+            Identifier(NotInSource, BinaryOperator.Equal.idStr),
             DualFinPluginInstantiation
         ) { t: Value, args: List<Value> ->
             (t as EqualityValue).evalEquals(args.first())
@@ -436,7 +436,7 @@ object DecimalEqualityOpMembers {
 
         val inputSubstitution = Substitution(listOf(decimalTypeParam), listOf(inputTypeArg))
         val inputType = inputSubstitution.apply(decimalType)
-        val formalParamId = Identifier("other")
+        val formalParamId = Identifier(NotInSource, "other")
         val formalParam = FunctionFormalParameterSymbol(res, formalParamId, inputType)
         res.define(formalParamId, formalParam)
         res.formalParams = listOf(formalParam)
@@ -465,7 +465,7 @@ object DecimalEqualityOpMembers {
     ): ParameterizedMemberPluginSymbol {
         val res = ParameterizedMemberPluginSymbol(
             decimalType,
-            Identifier(BinaryOperator.NotEqual.idStr),
+            Identifier(NotInSource, BinaryOperator.NotEqual.idStr),
             DualFinPluginInstantiation
         ) { t: Value, args: List<Value> ->
             (t as EqualityValue).evalNotEquals(args.first())
@@ -476,7 +476,7 @@ object DecimalEqualityOpMembers {
 
         val inputSubstitution = Substitution(listOf(decimalTypeParam), listOf(inputTypeArg))
         val inputType = inputSubstitution.apply(decimalType)
-        val formalParamId = Identifier("other")
+        val formalParamId = Identifier(NotInSource, "other")
         val formalParam = FunctionFormalParameterSymbol(res, formalParamId, inputType)
         res.define(formalParamId, formalParam)
         res.formalParams = listOf(formalParam)

--- a/src/main/kotlin/org/shardscript/semantics/prelude/DictionaryTypes.kt
+++ b/src/main/kotlin/org/shardscript/semantics/prelude/DictionaryTypes.kt
@@ -9,7 +9,7 @@ private fun createGetFunction(
     dictionaryKeyTypeParam: StandardTypeParameter,
     dictionaryValueTypeParam: StandardTypeParameter
 ) {
-    val getId = Identifier(CollectionMethods.KeyLookup.idStr)
+    val getId = Identifier(NotInSource, CollectionMethods.KeyLookup.idStr)
     val getMemberFunction = ParameterizedMemberPluginSymbol(
         dictionaryType,
         getId,
@@ -19,7 +19,7 @@ private fun createGetFunction(
     }
     getMemberFunction.typeParams = listOf(dictionaryKeyTypeParam, dictionaryValueTypeParam)
     getMemberFunction.costExpression = costExpression
-    val getFormalParamId = Identifier("key")
+    val getFormalParamId = Identifier(NotInSource, "key")
     val getFormalParam = FunctionFormalParameterSymbol(getMemberFunction, getFormalParamId, dictionaryKeyTypeParam)
     getMemberFunction.define(getFormalParamId, getFormalParam)
 
@@ -34,7 +34,7 @@ private fun createContainsFunction(
     dictionaryKeyTypeParam: StandardTypeParameter,
     booleanType: BasicTypeSymbol
 ) {
-    val containsId = Identifier(CollectionMethods.Contains.idStr)
+    val containsId = Identifier(NotInSource, CollectionMethods.Contains.idStr)
     val containsMemberFunction = ParameterizedMemberPluginSymbol(
         dictionaryType,
         containsId,
@@ -44,7 +44,7 @@ private fun createContainsFunction(
     }
     containsMemberFunction.typeParams = listOf(dictionaryKeyTypeParam)
     containsMemberFunction.costExpression = costExpression
-    val containsFormalParamId = Identifier("key")
+    val containsFormalParamId = Identifier(NotInSource, "key")
     val containsFormalParam =
         FunctionFormalParameterSymbol(containsMemberFunction, containsFormalParamId, dictionaryKeyTypeParam)
     containsMemberFunction.define(containsFormalParamId, containsFormalParam)
@@ -61,7 +61,7 @@ private fun createSetFunction(
     dictionaryKeyTypeParam: StandardTypeParameter,
     dictionaryValueTypeParam: StandardTypeParameter
 ) {
-    val setId = Identifier(CollectionMethods.KeyAssign.idStr)
+    val setId = Identifier(NotInSource, CollectionMethods.KeyAssign.idStr)
     val setMemberFunction = ParameterizedMemberPluginSymbol(
         dictionaryType,
         setId,
@@ -71,11 +71,11 @@ private fun createSetFunction(
     }
     setMemberFunction.typeParams = listOf(dictionaryKeyTypeParam, dictionaryValueTypeParam)
     setMemberFunction.costExpression = costExpression
-    val keyFormalParamId = Identifier("key")
+    val keyFormalParamId = Identifier(NotInSource, "key")
     val keyFormalParam = FunctionFormalParameterSymbol(setMemberFunction, keyFormalParamId, dictionaryKeyTypeParam)
     setMemberFunction.define(keyFormalParamId, keyFormalParam)
 
-    val valueFormalParamId = Identifier("value")
+    val valueFormalParamId = Identifier(NotInSource, "value")
     val valueFormalParam =
         FunctionFormalParameterSymbol(setMemberFunction, valueFormalParamId, dictionaryValueTypeParam)
     setMemberFunction.define(valueFormalParamId, valueFormalParam)
@@ -91,7 +91,7 @@ private fun createRemoveFunction(
     unitType: ObjectSymbol,
     dictionaryKeyTypeParam: StandardTypeParameter
 ) {
-    val removeId = Identifier(CollectionMethods.Remove.idStr)
+    val removeId = Identifier(NotInSource, CollectionMethods.Remove.idStr)
     val removeMemberFunction = ParameterizedMemberPluginSymbol(
         dictionaryType,
         removeId,
@@ -101,7 +101,7 @@ private fun createRemoveFunction(
     }
     removeMemberFunction.typeParams = listOf(dictionaryKeyTypeParam)
     removeMemberFunction.costExpression = costExpression
-    val removeFormalParamId = Identifier("key")
+    val removeFormalParamId = Identifier(NotInSource, "key")
     val removeFormalParam =
         FunctionFormalParameterSymbol(removeMemberFunction, removeFormalParamId, dictionaryKeyTypeParam)
     removeMemberFunction.define(removeFormalParamId, removeFormalParam)
@@ -120,7 +120,7 @@ fun createToImmutableDictionaryPlugin(
 ) {
     val plugin = ParameterizedMemberPluginSymbol(
         mutableDictionaryType,
-        Identifier(CollectionMethods.ToImmutableDictionary.idStr),
+        Identifier(NotInSource, CollectionMethods.ToImmutableDictionary.idStr),
         TripleParentArgInstantiation
     ) { t: Value, _: List<Value> ->
         (t as DictionaryValue).evalToDictionary()
@@ -178,7 +178,7 @@ fun dictionaryCollectionType(
         booleanType
     )
 
-    val sizeId = Identifier(CollectionFields.Size.idStr)
+    val sizeId = Identifier(NotInSource, CollectionFields.Size.idStr)
     val sizeFieldSymbol = PlatformFieldSymbol(
         dictionaryType,
         sizeId,
@@ -282,7 +282,7 @@ fun mutableDictionaryCollectionType(
         dictionaryType
     )
 
-    val sizeId = Identifier(CollectionFields.Size.idStr)
+    val sizeId = Identifier(NotInSource, CollectionFields.Size.idStr)
     val sizeFieldSymbol = PlatformFieldSymbol(
         mutableDictionaryType,
         sizeId,

--- a/src/main/kotlin/org/shardscript/semantics/prelude/EqualityMembers.kt
+++ b/src/main/kotlin/org/shardscript/semantics/prelude/EqualityMembers.kt
@@ -16,7 +16,7 @@ fun createListEqualsMember(
 ) {
     val equalsMemberFunction = ParameterizedMemberPluginSymbol(
         listSymbol,
-        Identifier(BinaryOperator.Equal.idStr),
+        Identifier(NotInSource, BinaryOperator.Equal.idStr),
         DoubleParentSingleFinPluginInstantiation
     ) { t: Value, args: List<Value> ->
         (t as EqualityValue).evalEquals(args.first())
@@ -30,7 +30,7 @@ fun createListEqualsMember(
     val inputSubstitution = Substitution(listSymbol.typeParams, listOf(listElementType, inputFinTypeArg))
     val inputType = inputSubstitution.apply(listSymbol)
 
-    val otherParam = FunctionFormalParameterSymbol(equalsMemberFunction, Identifier("other"), inputType)
+    val otherParam = FunctionFormalParameterSymbol(equalsMemberFunction, Identifier(NotInSource, "other"), inputType)
     equalsMemberFunction.formalParams = listOf(otherParam)
     equalsMemberFunction.returnType = booleanType
     equalsMemberFunction.costExpression = SumCostExpression(
@@ -51,7 +51,7 @@ fun createListNotEqualsMember(
 ) {
     val notEqualsMemberFunction = ParameterizedMemberPluginSymbol(
         listSymbol,
-        Identifier(BinaryOperator.NotEqual.idStr),
+        Identifier(NotInSource, BinaryOperator.NotEqual.idStr),
         DoubleParentSingleFinPluginInstantiation
     ) { t: Value, args: List<Value> ->
         (t as EqualityValue).evalNotEquals(args.first())
@@ -65,7 +65,7 @@ fun createListNotEqualsMember(
     val inputSubstitution = Substitution(listSymbol.typeParams, listOf(listElementType, inputFinTypeArg))
     val inputType = inputSubstitution.apply(listSymbol)
 
-    val otherParam = FunctionFormalParameterSymbol(notEqualsMemberFunction, Identifier("other"), inputType)
+    val otherParam = FunctionFormalParameterSymbol(notEqualsMemberFunction, Identifier(NotInSource, "other"), inputType)
     notEqualsMemberFunction.formalParams = listOf(otherParam)
     notEqualsMemberFunction.returnType = booleanType
     notEqualsMemberFunction.costExpression = SumCostExpression(
@@ -86,7 +86,7 @@ fun createMutableListEqualsMember(
 ) {
     val equalsMemberFunction = ParameterizedMemberPluginSymbol(
         mutableListSymbol,
-        Identifier(BinaryOperator.Equal.idStr),
+        Identifier(NotInSource, BinaryOperator.Equal.idStr),
         DoubleParentSingleFinPluginInstantiation
     ) { t: Value, args: List<Value> ->
         (t as EqualityValue).evalEquals(args.first())
@@ -101,7 +101,7 @@ fun createMutableListEqualsMember(
         Substitution(mutableListSymbol.typeParams, listOf(mutableListElementType, inputFinTypeArg))
     val inputType = inputSubstitution.apply(mutableListSymbol)
 
-    val otherParam = FunctionFormalParameterSymbol(equalsMemberFunction, Identifier("other"), inputType)
+    val otherParam = FunctionFormalParameterSymbol(equalsMemberFunction, Identifier(NotInSource, "other"), inputType)
     equalsMemberFunction.formalParams = listOf(otherParam)
     equalsMemberFunction.returnType = booleanType
     equalsMemberFunction.costExpression = SumCostExpression(
@@ -122,7 +122,7 @@ fun createMutableListNotEqualsMember(
 ) {
     val notEqualsMemberFunction = ParameterizedMemberPluginSymbol(
         mutableListSymbol,
-        Identifier(BinaryOperator.NotEqual.idStr),
+        Identifier(NotInSource, BinaryOperator.NotEqual.idStr),
         DoubleParentSingleFinPluginInstantiation
     ) { t: Value, args: List<Value> ->
         (t as EqualityValue).evalNotEquals(args.first())
@@ -137,7 +137,7 @@ fun createMutableListNotEqualsMember(
         Substitution(mutableListSymbol.typeParams, listOf(mutableListElementType, inputFinTypeArg))
     val inputType = inputSubstitution.apply(mutableListSymbol)
 
-    val otherParam = FunctionFormalParameterSymbol(notEqualsMemberFunction, Identifier("other"), inputType)
+    val otherParam = FunctionFormalParameterSymbol(notEqualsMemberFunction, Identifier(NotInSource, "other"), inputType)
     notEqualsMemberFunction.formalParams = listOf(otherParam)
     notEqualsMemberFunction.returnType = booleanType
     notEqualsMemberFunction.costExpression = SumCostExpression(
@@ -162,7 +162,7 @@ fun createDictionaryEqualsMember(
 ) {
     val equalsMemberFunction = ParameterizedMemberPluginSymbol(
         dictionarySymbol,
-        Identifier(BinaryOperator.Equal.idStr),
+        Identifier(NotInSource, BinaryOperator.Equal.idStr),
         TripleParentSingleFinPluginInstantiation
     ) { t: Value, args: List<Value> ->
         (t as EqualityValue).evalEquals(args.first())
@@ -178,7 +178,7 @@ fun createDictionaryEqualsMember(
         Substitution(dictionarySymbol.typeParams, listOf(dictionaryKeyType, dictionaryValueType, inputFinTypeArg))
     val inputType = inputSubstitution.apply(dictionarySymbol)
 
-    val otherParam = FunctionFormalParameterSymbol(equalsMemberFunction, Identifier("other"), inputType)
+    val otherParam = FunctionFormalParameterSymbol(equalsMemberFunction, Identifier(NotInSource, "other"), inputType)
     equalsMemberFunction.formalParams = listOf(otherParam)
     equalsMemberFunction.returnType = booleanType
     equalsMemberFunction.costExpression = SumCostExpression(
@@ -200,7 +200,7 @@ fun createDictionaryNotEqualsMember(
 ) {
     val notEqualsMemberFunction = ParameterizedMemberPluginSymbol(
         dictionarySymbol,
-        Identifier(BinaryOperator.NotEqual.idStr),
+        Identifier(NotInSource, BinaryOperator.NotEqual.idStr),
         TripleParentSingleFinPluginInstantiation
     ) { t: Value, args: List<Value> ->
         (t as EqualityValue).evalNotEquals(args.first())
@@ -216,7 +216,7 @@ fun createDictionaryNotEqualsMember(
         Substitution(dictionarySymbol.typeParams, listOf(dictionaryKeyType, dictionaryValueType, inputFinTypeArg))
     val inputType = inputSubstitution.apply(dictionarySymbol)
 
-    val otherParam = FunctionFormalParameterSymbol(notEqualsMemberFunction, Identifier("other"), inputType)
+    val otherParam = FunctionFormalParameterSymbol(notEqualsMemberFunction, Identifier(NotInSource, "other"), inputType)
     notEqualsMemberFunction.formalParams = listOf(otherParam)
     notEqualsMemberFunction.returnType = booleanType
     notEqualsMemberFunction.costExpression = SumCostExpression(
@@ -238,7 +238,7 @@ fun createMutableDictionaryEqualsMember(
 ) {
     val equalsMemberFunction = ParameterizedMemberPluginSymbol(
         mutableDictionarySymbol,
-        Identifier(BinaryOperator.Equal.idStr),
+        Identifier(NotInSource, BinaryOperator.Equal.idStr),
         TripleParentSingleFinPluginInstantiation
     ) { t: Value, args: List<Value> ->
         (t as EqualityValue).evalEquals(args.first())
@@ -257,7 +257,7 @@ fun createMutableDictionaryEqualsMember(
     )
     val inputType = inputSubstitution.apply(mutableDictionarySymbol)
 
-    val otherParam = FunctionFormalParameterSymbol(equalsMemberFunction, Identifier("other"), inputType)
+    val otherParam = FunctionFormalParameterSymbol(equalsMemberFunction, Identifier(NotInSource, "other"), inputType)
     equalsMemberFunction.formalParams = listOf(otherParam)
     equalsMemberFunction.returnType = booleanType
     equalsMemberFunction.costExpression = SumCostExpression(
@@ -279,7 +279,7 @@ fun createMutableDictionaryNotEqualsMember(
 ) {
     val notEqualsMemberFunction = ParameterizedMemberPluginSymbol(
         mutableDictionarySymbol,
-        Identifier(BinaryOperator.NotEqual.idStr),
+        Identifier(NotInSource, BinaryOperator.NotEqual.idStr),
         TripleParentSingleFinPluginInstantiation
     ) { t: Value, args: List<Value> ->
         (t as EqualityValue).evalNotEquals(args.first())
@@ -298,7 +298,7 @@ fun createMutableDictionaryNotEqualsMember(
     )
     val inputType = inputSubstitution.apply(mutableDictionarySymbol)
 
-    val otherParam = FunctionFormalParameterSymbol(notEqualsMemberFunction, Identifier("other"), inputType)
+    val otherParam = FunctionFormalParameterSymbol(notEqualsMemberFunction, Identifier(NotInSource, "other"), inputType)
     notEqualsMemberFunction.formalParams = listOf(otherParam)
     notEqualsMemberFunction.returnType = booleanType
     notEqualsMemberFunction.costExpression = SumCostExpression(
@@ -322,7 +322,7 @@ fun createSetEqualsMember(
 ) {
     val equalsMemberFunction = ParameterizedMemberPluginSymbol(
         setSymbol,
-        Identifier(BinaryOperator.Equal.idStr),
+        Identifier(NotInSource, BinaryOperator.Equal.idStr),
         DoubleParentSingleFinPluginInstantiation
     ) { t: Value, args: List<Value> ->
         (t as EqualityValue).evalEquals(args.first())
@@ -336,7 +336,7 @@ fun createSetEqualsMember(
     val inputSubstitution = Substitution(setSymbol.typeParams, listOf(setElementType, inputFinTypeArg))
     val inputType = inputSubstitution.apply(setSymbol)
 
-    val otherParam = FunctionFormalParameterSymbol(equalsMemberFunction, Identifier("other"), inputType)
+    val otherParam = FunctionFormalParameterSymbol(equalsMemberFunction, Identifier(NotInSource, "other"), inputType)
     equalsMemberFunction.formalParams = listOf(otherParam)
     equalsMemberFunction.returnType = booleanType
     equalsMemberFunction.costExpression = SumCostExpression(
@@ -357,7 +357,7 @@ fun createSetNotEqualsMember(
 ) {
     val notEqualsMemberFunction = ParameterizedMemberPluginSymbol(
         setSymbol,
-        Identifier(BinaryOperator.NotEqual.idStr),
+        Identifier(NotInSource, BinaryOperator.NotEqual.idStr),
         DoubleParentSingleFinPluginInstantiation
     ) { t: Value, args: List<Value> ->
         (t as EqualityValue).evalNotEquals(args.first())
@@ -371,7 +371,7 @@ fun createSetNotEqualsMember(
     val inputSubstitution = Substitution(setSymbol.typeParams, listOf(setElementType, inputFinTypeArg))
     val inputType = inputSubstitution.apply(setSymbol)
 
-    val otherParam = FunctionFormalParameterSymbol(notEqualsMemberFunction, Identifier("other"), inputType)
+    val otherParam = FunctionFormalParameterSymbol(notEqualsMemberFunction, Identifier(NotInSource, "other"), inputType)
     notEqualsMemberFunction.formalParams = listOf(otherParam)
     notEqualsMemberFunction.returnType = booleanType
     notEqualsMemberFunction.costExpression = SumCostExpression(
@@ -392,7 +392,7 @@ fun createMutableSetEqualsMember(
 ) {
     val equalsMemberFunction = ParameterizedMemberPluginSymbol(
         mutableSetSymbol,
-        Identifier(BinaryOperator.Equal.idStr),
+        Identifier(NotInSource, BinaryOperator.Equal.idStr),
         DoubleParentSingleFinPluginInstantiation
     ) { t: Value, args: List<Value> ->
         (t as EqualityValue).evalEquals(args.first())
@@ -407,7 +407,7 @@ fun createMutableSetEqualsMember(
         Substitution(mutableSetSymbol.typeParams, listOf(mutableSetElementType, inputFinTypeArg))
     val inputType = inputSubstitution.apply(mutableSetSymbol)
 
-    val otherParam = FunctionFormalParameterSymbol(equalsMemberFunction, Identifier("other"), inputType)
+    val otherParam = FunctionFormalParameterSymbol(equalsMemberFunction, Identifier(NotInSource, "other"), inputType)
     equalsMemberFunction.formalParams = listOf(otherParam)
     equalsMemberFunction.returnType = booleanType
     equalsMemberFunction.costExpression = SumCostExpression(
@@ -428,7 +428,7 @@ fun createMutableSetNotEqualsMember(
 ) {
     val notEqualsMemberFunction = ParameterizedMemberPluginSymbol(
         mutableSetSymbol,
-        Identifier(BinaryOperator.NotEqual.idStr),
+        Identifier(NotInSource, BinaryOperator.NotEqual.idStr),
         DoubleParentSingleFinPluginInstantiation
     ) { t: Value, args: List<Value> ->
         (t as EqualityValue).evalNotEquals(args.first())
@@ -443,7 +443,7 @@ fun createMutableSetNotEqualsMember(
         Substitution(mutableSetSymbol.typeParams, listOf(mutableSetElementType, inputFinTypeArg))
     val inputType = inputSubstitution.apply(mutableSetSymbol)
 
-    val otherParam = FunctionFormalParameterSymbol(notEqualsMemberFunction, Identifier("other"), inputType)
+    val otherParam = FunctionFormalParameterSymbol(notEqualsMemberFunction, Identifier(NotInSource, "other"), inputType)
     notEqualsMemberFunction.formalParams = listOf(otherParam)
     notEqualsMemberFunction.returnType = booleanType
     notEqualsMemberFunction.costExpression = SumCostExpression(

--- a/src/main/kotlin/org/shardscript/semantics/prelude/Lang.kt
+++ b/src/main/kotlin/org/shardscript/semantics/prelude/Lang.kt
@@ -3,62 +3,62 @@ package org.shardscript.semantics.prelude
 import org.shardscript.semantics.core.*
 
 object Lang {
-    val shardId = Identifier("shard")
-    val langId = Identifier("lang")
-    val unitId = Identifier("Unit")
-    val booleanId = Identifier("Boolean")
-    val intId = Identifier("Int")
-    val charId = Identifier("Char")
-    val stringId = Identifier("String")
-    val stringTypeId = Identifier("O")
-    val stringInputTypeId = Identifier("P")
+    val shardId = Identifier(NotInSource, "shard")
+    val langId = Identifier(NotInSource, "lang")
+    val unitId = Identifier(NotInSource, "Unit")
+    val booleanId = Identifier(NotInSource, "Boolean")
+    val intId = Identifier(NotInSource, "Int")
+    val charId = Identifier(NotInSource, "Char")
+    val stringId = Identifier(NotInSource, "String")
+    val stringTypeId = Identifier(NotInSource, "O")
+    val stringInputTypeId = Identifier(NotInSource, "P")
 
-    val decimalId = Identifier("Decimal")
-    val decimalTypeId = Identifier("O")
-    val decimalInputTypeId = Identifier("P")
+    val decimalId = Identifier(NotInSource, "Decimal")
+    val decimalTypeId = Identifier(NotInSource, "O")
+    val decimalInputTypeId = Identifier(NotInSource, "P")
 
-    val listId = Identifier("List")
-    val listElementTypeId = Identifier("E")
-    val listFinTypeId = Identifier("O")
-    val listInputFinTypeId = Identifier("P")
+    val listId = Identifier(NotInSource, "List")
+    val listElementTypeId = Identifier(NotInSource, "E")
+    val listFinTypeId = Identifier(NotInSource, "O")
+    val listInputFinTypeId = Identifier(NotInSource, "P")
 
-    val mutableListId = Identifier("MutableList")
-    val mutableListElementTypeId = Identifier("E")
-    val mutableListFinTypeId = Identifier("O")
-    val mutableListInputFinTypeId = Identifier("P")
+    val mutableListId = Identifier(NotInSource, "MutableList")
+    val mutableListElementTypeId = Identifier(NotInSource, "E")
+    val mutableListFinTypeId = Identifier(NotInSource, "O")
+    val mutableListInputFinTypeId = Identifier(NotInSource, "P")
 
-    val pairId = Identifier("Pair")
-    private val pairFirstTypeId = Identifier("A")
-    private val pairSecondTypeId = Identifier("B")
-    val pairFirstId = Identifier("first")
-    val pairSecondId = Identifier("second")
+    val pairId = Identifier(NotInSource, "Pair")
+    private val pairFirstTypeId = Identifier(NotInSource, "A")
+    private val pairSecondTypeId = Identifier(NotInSource, "B")
+    val pairFirstId = Identifier(NotInSource, "first")
+    val pairSecondId = Identifier(NotInSource, "second")
 
-    val dictionaryId = Identifier("Dictionary")
-    val dictionaryKeyTypeId = Identifier("K")
-    val dictionaryValueTypeId = Identifier("V")
-    val dictionaryFinTypeId = Identifier("O")
-    val dictionaryInputFinTypeId = Identifier("P")
+    val dictionaryId = Identifier(NotInSource, "Dictionary")
+    val dictionaryKeyTypeId = Identifier(NotInSource, "K")
+    val dictionaryValueTypeId = Identifier(NotInSource, "V")
+    val dictionaryFinTypeId = Identifier(NotInSource, "O")
+    val dictionaryInputFinTypeId = Identifier(NotInSource, "P")
 
-    val mutableDictionaryId = Identifier("MutableDictionary")
-    val mutableDictionaryKeyTypeId = Identifier("K")
-    val mutableDictionaryValueTypeId = Identifier("V")
-    val mutableDictionaryFinTypeId = Identifier("O")
-    val mutableDictionaryInputFinTypeId = Identifier("P")
+    val mutableDictionaryId = Identifier(NotInSource, "MutableDictionary")
+    val mutableDictionaryKeyTypeId = Identifier(NotInSource, "K")
+    val mutableDictionaryValueTypeId = Identifier(NotInSource, "V")
+    val mutableDictionaryFinTypeId = Identifier(NotInSource, "O")
+    val mutableDictionaryInputFinTypeId = Identifier(NotInSource, "P")
 
-    val setId = Identifier("Set")
-    val setElementTypeId = Identifier("E")
-    val setFinTypeId = Identifier("O")
-    val setInputFinTypeId = Identifier("P")
+    val setId = Identifier(NotInSource, "Set")
+    val setElementTypeId = Identifier(NotInSource, "E")
+    val setFinTypeId = Identifier(NotInSource, "O")
+    val setInputFinTypeId = Identifier(NotInSource, "P")
 
-    val mutableSetId = Identifier("MutableSet")
-    val mutableSetElementTypeId = Identifier("E")
-    val mutableSetFinTypeId = Identifier("O")
-    val mutableSetInputFinTypeId = Identifier("P")
+    val mutableSetId = Identifier(NotInSource, "MutableSet")
+    val mutableSetElementTypeId = Identifier(NotInSource, "E")
+    val mutableSetFinTypeId = Identifier(NotInSource, "O")
+    val mutableSetInputFinTypeId = Identifier(NotInSource, "P")
 
-    val rangeId = Identifier("range")
-    val rangeTypeId = Identifier("O")
-    val randomId = Identifier("random")
-    val randomTypeId = Identifier("A")
+    val rangeId = Identifier(NotInSource, "range")
+    val rangeTypeId = Identifier(NotInSource, "O")
+    val randomId = Identifier(NotInSource, "random")
+    val randomTypeId = Identifier(NotInSource, "A")
 
     const val INT_FIN: Long = (Int.MIN_VALUE.toString().length).toLong()
     val unitFin: Long = unitId.name.length.toLong()
@@ -98,11 +98,11 @@ object Lang {
         )
         val constantFin = FinTypeSymbol(architecture.defaultNodeCost)
         ValueEqualityOpMembers.members(booleanType, constantFin, booleanType).forEach { (name, plugin) ->
-            booleanType.define(Identifier(name), plugin)
+            booleanType.define(Identifier(NotInSource, name), plugin)
         }
 
         ValueLogicalOpMembers.members(booleanType, constantFin).forEach { (name, plugin) ->
-            booleanType.define(Identifier(name), plugin)
+            booleanType.define(Identifier(NotInSource, name), plugin)
         }
 
         // Integer
@@ -117,7 +117,7 @@ object Lang {
             charId
         )
         ValueEqualityOpMembers.members(charType, constantFin, charType).forEach { (name, plugin) ->
-            charType.define(Identifier(name), plugin)
+            charType.define(Identifier(NotInSource, name), plugin)
         }
 
         // List

--- a/src/main/kotlin/org/shardscript/semantics/prelude/ListTypes.kt
+++ b/src/main/kotlin/org/shardscript/semantics/prelude/ListTypes.kt
@@ -9,7 +9,7 @@ private fun createGetFunction(
     intType: BasicTypeSymbol,
     listElementTypeParam: StandardTypeParameter
 ) {
-    val getId = Identifier(CollectionMethods.IndexLookup.idStr)
+    val getId = Identifier(NotInSource, CollectionMethods.IndexLookup.idStr)
     val getMemberFunction = ParameterizedMemberPluginSymbol(
         listType,
         getId,
@@ -19,7 +19,7 @@ private fun createGetFunction(
     }
     getMemberFunction.typeParams = listOf(listElementTypeParam)
     getMemberFunction.costExpression = costExpression
-    val getFormalParamId = Identifier("index")
+    val getFormalParamId = Identifier(NotInSource, "index")
     val getFormalParam = FunctionFormalParameterSymbol(getMemberFunction, getFormalParamId, intType)
     getMemberFunction.define(getFormalParamId, getFormalParam)
 
@@ -34,7 +34,7 @@ private fun createAddFunction(
     unitType: ObjectSymbol,
     listElementTypeParam: StandardTypeParameter
 ) {
-    val addId = Identifier(CollectionMethods.InsertElement.idStr)
+    val addId = Identifier(NotInSource, CollectionMethods.InsertElement.idStr)
     val addMemberFunction = ParameterizedMemberPluginSymbol(
         listType,
         addId,
@@ -44,7 +44,7 @@ private fun createAddFunction(
     }
     addMemberFunction.typeParams = listOf(listElementTypeParam)
     addMemberFunction.costExpression = costExpression
-    val addFormalParamId = Identifier("element")
+    val addFormalParamId = Identifier(NotInSource, "element")
     val addFormalParam = FunctionFormalParameterSymbol(addMemberFunction, addFormalParamId, listElementTypeParam)
     addMemberFunction.define(addFormalParamId, addFormalParam)
 
@@ -60,7 +60,7 @@ private fun createSetFunction(
     intType: BasicTypeSymbol,
     listElementTypeParam: StandardTypeParameter
 ) {
-    val setId = Identifier(CollectionMethods.IndexAssign.idStr)
+    val setId = Identifier(NotInSource, CollectionMethods.IndexAssign.idStr)
     val setMemberFunction = ParameterizedMemberPluginSymbol(
         listType,
         setId,
@@ -70,11 +70,11 @@ private fun createSetFunction(
     }
     setMemberFunction.typeParams = listOf(listElementTypeParam)
     setMemberFunction.costExpression = costExpression
-    val indexFormalParamId = Identifier("index")
+    val indexFormalParamId = Identifier(NotInSource, "index")
     val indexFormalParam = FunctionFormalParameterSymbol(setMemberFunction, indexFormalParamId, intType)
     setMemberFunction.define(indexFormalParamId, indexFormalParam)
 
-    val valueFormalParamId = Identifier("value")
+    val valueFormalParamId = Identifier(NotInSource, "value")
     val valueFormalParam = FunctionFormalParameterSymbol(setMemberFunction, valueFormalParamId, listElementTypeParam)
     setMemberFunction.define(valueFormalParamId, valueFormalParam)
 
@@ -89,7 +89,7 @@ private fun createRemoveAtFunction(
     unitType: ObjectSymbol,
     intType: BasicTypeSymbol
 ) {
-    val removeAtId = Identifier(CollectionMethods.RemoveAtIndex.idStr)
+    val removeAtId = Identifier(NotInSource, CollectionMethods.RemoveAtIndex.idStr)
     val removeAtMemberFunction = GroundMemberPluginSymbol(
         listType,
         removeAtId
@@ -97,7 +97,7 @@ private fun createRemoveAtFunction(
         (t as ListValue).evalRemoveAt(args.first())
     }
     removeAtMemberFunction.costExpression = costExpression
-    val removeAtFormalParamId = Identifier("index")
+    val removeAtFormalParamId = Identifier(NotInSource, "index")
     val removeAtFormalParam = FunctionFormalParameterSymbol(removeAtMemberFunction, removeAtFormalParamId, intType)
     removeAtMemberFunction.define(removeAtFormalParamId, removeAtFormalParam)
 
@@ -114,7 +114,7 @@ fun createToImmutableListPlugin(
 ) {
     val plugin = ParameterizedMemberPluginSymbol(
         mutableListType,
-        Identifier(CollectionMethods.ToImmutableList.idStr),
+        Identifier(NotInSource, CollectionMethods.ToImmutableList.idStr),
         DoubleParentArgInstantiation
     ) { t: Value, _: List<Value> ->
         (t as ListValue).evalToList()
@@ -162,7 +162,7 @@ fun listCollectionType(
         listElementTypeParam
     )
 
-    val sizeId = Identifier(CollectionFields.Size.idStr)
+    val sizeId = Identifier(NotInSource, CollectionFields.Size.idStr)
     val sizeFieldSymbol = PlatformFieldSymbol(
         listType,
         sizeId,
@@ -247,7 +247,7 @@ fun mutableListCollectionType(
         listType
     )
 
-    val sizeId = Identifier(CollectionFields.Size.idStr)
+    val sizeId = Identifier(NotInSource, CollectionFields.Size.idStr)
     val sizeFieldSymbol = PlatformFieldSymbol(
         mutableListType,
         sizeId,

--- a/src/main/kotlin/org/shardscript/semantics/prelude/NumericTypes.kt
+++ b/src/main/kotlin/org/shardscript/semantics/prelude/NumericTypes.kt
@@ -17,17 +17,17 @@ fun intType(
     val constantFin = FinTypeSymbol(architecture.defaultNodeCost)
     IntegerMathOpMembers.members(intType, constantFin).forEach { (name, plugin) ->
         if (!filters.contains(name)) {
-            intType.define(Identifier(name), plugin)
+            intType.define(Identifier(NotInSource, name), plugin)
         }
     }
     IntegerOrderOpMembers.members(intType, constantFin, booleanType).forEach { (name, plugin) ->
         if (!filters.contains(name)) {
-            intType.define(Identifier(name), plugin)
+            intType.define(Identifier(NotInSource, name), plugin)
         }
     }
     ValueEqualityOpMembers.members(intType, constantFin, booleanType).forEach { (name, plugin) ->
         if (!filters.contains(name)) {
-            intType.define(Identifier(name), plugin)
+            intType.define(Identifier(NotInSource, name), plugin)
         }
     }
     return intType
@@ -54,13 +54,13 @@ fun decimalType(
     decimalType.fields = listOf()
 
     DecimalMathOpMembers.members(decimalType, decimalTypeParam).forEach { (name, plugin) ->
-        decimalType.define(Identifier(name), plugin)
+        decimalType.define(Identifier(NotInSource, name), plugin)
     }
     DecimalOrderOpMembers.members(decimalType, decimalTypeParam, booleanType).forEach { (name, plugin) ->
-        decimalType.define(Identifier(name), plugin)
+        decimalType.define(Identifier(NotInSource, name), plugin)
     }
     DecimalEqualityOpMembers.members(decimalType, decimalTypeParam, booleanType).forEach { (name, plugin) ->
-        decimalType.define(Identifier(name), plugin)
+        decimalType.define(Identifier(NotInSource, name), plugin)
     }
     return decimalType
 }

--- a/src/main/kotlin/org/shardscript/semantics/prelude/OpMembers.kt
+++ b/src/main/kotlin/org/shardscript/semantics/prelude/OpMembers.kt
@@ -15,12 +15,12 @@ object IntegerMathOpMembers {
     private fun pluginAdd(valueType: BasicTypeSymbol, costExpression: CostExpression): GroundMemberPluginSymbol {
         val res = GroundMemberPluginSymbol(
             valueType,
-            Identifier(BinaryOperator.Add.idStr)
+            Identifier(NotInSource, BinaryOperator.Add.idStr)
         ) { t: Value, args: List<Value> ->
             (t as MathValue).evalAdd(args.first())
         }
         res.costExpression = costExpression
-        val formalParamId = Identifier("other")
+        val formalParamId = Identifier(NotInSource, "other")
         val formalParam = FunctionFormalParameterSymbol(res, formalParamId, valueType)
         res.define(formalParamId, formalParam)
 
@@ -32,12 +32,12 @@ object IntegerMathOpMembers {
     private fun pluginSub(valueType: BasicTypeSymbol, costExpression: CostExpression): GroundMemberPluginSymbol {
         val res = GroundMemberPluginSymbol(
             valueType,
-            Identifier(BinaryOperator.Sub.idStr)
+            Identifier(NotInSource, BinaryOperator.Sub.idStr)
         ) { t: Value, args: List<Value> ->
             (t as MathValue).evalSub(args.first())
         }
         res.costExpression = costExpression
-        val formalParamId = Identifier("other")
+        val formalParamId = Identifier(NotInSource, "other")
         val formalParam = FunctionFormalParameterSymbol(res, formalParamId, valueType)
         res.define(formalParamId, formalParam)
 
@@ -49,12 +49,12 @@ object IntegerMathOpMembers {
     private fun pluginMul(valueType: BasicTypeSymbol, costExpression: CostExpression): GroundMemberPluginSymbol {
         val res = GroundMemberPluginSymbol(
             valueType,
-            Identifier(BinaryOperator.Mul.idStr)
+            Identifier(NotInSource, BinaryOperator.Mul.idStr)
         ) { t: Value, args: List<Value> ->
             (t as MathValue).evalMul(args.first())
         }
         res.costExpression = costExpression
-        val formalParamId = Identifier("other")
+        val formalParamId = Identifier(NotInSource, "other")
         val formalParam = FunctionFormalParameterSymbol(res, formalParamId, valueType)
         res.define(formalParamId, formalParam)
 
@@ -66,12 +66,12 @@ object IntegerMathOpMembers {
     private fun pluginDiv(valueType: BasicTypeSymbol, costExpression: CostExpression): GroundMemberPluginSymbol {
         val res = GroundMemberPluginSymbol(
             valueType,
-            Identifier(BinaryOperator.Div.idStr)
+            Identifier(NotInSource, BinaryOperator.Div.idStr)
         ) { t: Value, args: List<Value> ->
             (t as MathValue).evalDiv(args.first())
         }
         res.costExpression = costExpression
-        val formalParamId = Identifier("other")
+        val formalParamId = Identifier(NotInSource, "other")
         val formalParam = FunctionFormalParameterSymbol(res, formalParamId, valueType)
         res.define(formalParamId, formalParam)
 
@@ -83,12 +83,12 @@ object IntegerMathOpMembers {
     private fun pluginMod(valueType: BasicTypeSymbol, costExpression: CostExpression): GroundMemberPluginSymbol {
         val res = GroundMemberPluginSymbol(
             valueType,
-            Identifier(BinaryOperator.Mod.idStr)
+            Identifier(NotInSource, BinaryOperator.Mod.idStr)
         ) { t: Value, args: List<Value> ->
             (t as MathValue).evalMod(args.first())
         }
         res.costExpression = costExpression
-        val formalParamId = Identifier("other")
+        val formalParamId = Identifier(NotInSource, "other")
         val formalParam = FunctionFormalParameterSymbol(res, formalParamId, valueType)
         res.define(formalParamId, formalParam)
 
@@ -100,7 +100,7 @@ object IntegerMathOpMembers {
     private fun pluginNegate(valueType: BasicTypeSymbol, costExpression: CostExpression): GroundMemberPluginSymbol {
         val res = GroundMemberPluginSymbol(
             valueType,
-            Identifier(UnaryOperator.Negate.idStr)
+            Identifier(NotInSource, UnaryOperator.Negate.idStr)
         ) { t: Value, _: List<Value> ->
             (t as MathValue).evalNegate()
         }
@@ -130,12 +130,12 @@ object IntegerOrderOpMembers {
     ): GroundMemberPluginSymbol {
         val res = GroundMemberPluginSymbol(
             valueType,
-            Identifier(BinaryOperator.GreaterThan.idStr)
+            Identifier(NotInSource, BinaryOperator.GreaterThan.idStr)
         ) { t: Value, args: List<Value> ->
             (t as OrderValue).evalGreaterThan(args.first())
         }
         res.costExpression = costExpression
-        val formalParamId = Identifier("other")
+        val formalParamId = Identifier(NotInSource, "other")
         val formalParam = FunctionFormalParameterSymbol(res, formalParamId, valueType)
         res.define(formalParamId, formalParam)
 
@@ -151,12 +151,12 @@ object IntegerOrderOpMembers {
     ): GroundMemberPluginSymbol {
         val res = GroundMemberPluginSymbol(
             valueType,
-            Identifier(BinaryOperator.GreaterThanEqual.idStr)
+            Identifier(NotInSource, BinaryOperator.GreaterThanEqual.idStr)
         ) { t: Value, args: List<Value> ->
             (t as OrderValue).evalGreaterThanOrEquals(args.first())
         }
         res.costExpression = costExpression
-        val formalParamId = Identifier("other")
+        val formalParamId = Identifier(NotInSource, "other")
         val formalParam = FunctionFormalParameterSymbol(res, formalParamId, valueType)
         res.define(formalParamId, formalParam)
 
@@ -172,12 +172,12 @@ object IntegerOrderOpMembers {
     ): GroundMemberPluginSymbol {
         val res = GroundMemberPluginSymbol(
             valueType,
-            Identifier(BinaryOperator.LessThan.idStr)
+            Identifier(NotInSource, BinaryOperator.LessThan.idStr)
         ) { t: Value, args: List<Value> ->
             (t as OrderValue).evalLessThan(args.first())
         }
         res.costExpression = costExpression
-        val formalParamId = Identifier("other")
+        val formalParamId = Identifier(NotInSource, "other")
         val formalParam = FunctionFormalParameterSymbol(res, formalParamId, valueType)
         res.define(formalParamId, formalParam)
 
@@ -193,12 +193,12 @@ object IntegerOrderOpMembers {
     ): GroundMemberPluginSymbol {
         val res = GroundMemberPluginSymbol(
             valueType,
-            Identifier(BinaryOperator.LessThanEqual.idStr)
+            Identifier(NotInSource, BinaryOperator.LessThanEqual.idStr)
         ) { t: Value, args: List<Value> ->
             (t as OrderValue).evalLessThanOrEquals(args.first())
         }
         res.costExpression = costExpression
-        val formalParamId = Identifier("other")
+        val formalParamId = Identifier(NotInSource, "other")
         val formalParam = FunctionFormalParameterSymbol(res, formalParamId, valueType)
         res.define(formalParamId, formalParam)
 
@@ -225,12 +225,12 @@ object ValueEqualityOpMembers {
     ): GroundMemberPluginSymbol {
         val res = GroundMemberPluginSymbol(
             valueType,
-            Identifier(BinaryOperator.Equal.idStr)
+            Identifier(NotInSource, BinaryOperator.Equal.idStr)
         ) { t: Value, args: List<Value> ->
             (t as EqualityValue).evalEquals(args.first())
         }
         res.costExpression = costExpression
-        val formalParamId = Identifier("other")
+        val formalParamId = Identifier(NotInSource, "other")
         val formalParam = FunctionFormalParameterSymbol(res, formalParamId, valueType)
         res.define(formalParamId, formalParam)
 
@@ -246,12 +246,12 @@ object ValueEqualityOpMembers {
     ): GroundMemberPluginSymbol {
         val res = GroundMemberPluginSymbol(
             valueType,
-            Identifier(BinaryOperator.NotEqual.idStr)
+            Identifier(NotInSource, BinaryOperator.NotEqual.idStr)
         ) { t: Value, args: List<Value> ->
             (t as EqualityValue).evalNotEquals(args.first())
         }
         res.costExpression = costExpression
-        val formalParamId = Identifier("other")
+        val formalParamId = Identifier(NotInSource, "other")
         val formalParam = FunctionFormalParameterSymbol(res, formalParamId, valueType)
         res.define(formalParamId, formalParam)
 
@@ -272,12 +272,12 @@ object ValueLogicalOpMembers {
     private fun pluginAnd(logicalType: BasicTypeSymbol, costExpression: CostExpression): GroundMemberPluginSymbol {
         val res = GroundMemberPluginSymbol(
             logicalType,
-            Identifier(BinaryOperator.And.idStr)
+            Identifier(NotInSource, BinaryOperator.And.idStr)
         ) { t: Value, args: List<Value> ->
             (t as LogicalValue).evalAnd(args.first())
         }
         res.costExpression = costExpression
-        val formalParamId = Identifier("other")
+        val formalParamId = Identifier(NotInSource, "other")
         val formalParam = FunctionFormalParameterSymbol(res, formalParamId, logicalType)
         res.define(formalParamId, formalParam)
 
@@ -289,12 +289,12 @@ object ValueLogicalOpMembers {
     private fun pluginOr(logicalType: BasicTypeSymbol, costExpression: CostExpression): GroundMemberPluginSymbol {
         val res = GroundMemberPluginSymbol(
             logicalType,
-            Identifier(BinaryOperator.Or.idStr)
+            Identifier(NotInSource, BinaryOperator.Or.idStr)
         ) { t: Value, args: List<Value> ->
             (t as LogicalValue).evalOr(args.first())
         }
         res.costExpression = costExpression
-        val formalParamId = Identifier("other")
+        val formalParamId = Identifier(NotInSource, "other")
         val formalParam = FunctionFormalParameterSymbol(res, formalParamId, logicalType)
         res.define(formalParamId, formalParam)
 
@@ -306,7 +306,7 @@ object ValueLogicalOpMembers {
     private fun pluginNot(logicalType: BasicTypeSymbol, costExpression: CostExpression): GroundMemberPluginSymbol {
         val res = GroundMemberPluginSymbol(
             logicalType,
-            Identifier(UnaryOperator.Not.idStr)
+            Identifier(NotInSource, UnaryOperator.Not.idStr)
         ) { t: Value, _: List<Value> ->
             (t as LogicalValue).evalNot()
         }

--- a/src/main/kotlin/org/shardscript/semantics/prelude/SetTypes.kt
+++ b/src/main/kotlin/org/shardscript/semantics/prelude/SetTypes.kt
@@ -9,7 +9,7 @@ private fun createContainsFunction(
     booleanType: BasicTypeSymbol,
     setElementTypeParam: StandardTypeParameter
 ) {
-    val containsId = Identifier(CollectionMethods.Contains.idStr)
+    val containsId = Identifier(NotInSource, CollectionMethods.Contains.idStr)
     val containsMemberFunction = ParameterizedMemberPluginSymbol(
         setType,
         containsId,
@@ -19,7 +19,7 @@ private fun createContainsFunction(
     }
     containsMemberFunction.typeParams = listOf(setElementTypeParam)
     containsMemberFunction.costExpression = costExpression
-    val containsFormalParamId = Identifier("element")
+    val containsFormalParamId = Identifier(NotInSource, "element")
     val containsFormalParam =
         FunctionFormalParameterSymbol(containsMemberFunction, containsFormalParamId, setElementTypeParam)
     containsMemberFunction.define(containsFormalParamId, containsFormalParam)
@@ -35,7 +35,7 @@ private fun createAddFunction(
     unitType: ObjectSymbol,
     setElementTypeParam: StandardTypeParameter
 ) {
-    val addId = Identifier(CollectionMethods.InsertElement.idStr)
+    val addId = Identifier(NotInSource, CollectionMethods.InsertElement.idStr)
     val addMemberFunction = ParameterizedMemberPluginSymbol(
         setType,
         addId,
@@ -45,7 +45,7 @@ private fun createAddFunction(
     }
     addMemberFunction.typeParams = listOf(setElementTypeParam)
     addMemberFunction.costExpression = costExpression
-    val addFormalParamId = Identifier("element")
+    val addFormalParamId = Identifier(NotInSource, "element")
     val addFormalParam = FunctionFormalParameterSymbol(addMemberFunction, addFormalParamId, setElementTypeParam)
     addMemberFunction.define(addFormalParamId, addFormalParam)
 
@@ -60,7 +60,7 @@ private fun createRemoveFunction(
     unitType: ObjectSymbol,
     setElementTypeParam: StandardTypeParameter
 ) {
-    val removeId = Identifier(CollectionMethods.Remove.idStr)
+    val removeId = Identifier(NotInSource, CollectionMethods.Remove.idStr)
     val removeMemberFunction = ParameterizedMemberPluginSymbol(
         setType,
         removeId,
@@ -70,7 +70,7 @@ private fun createRemoveFunction(
     }
     removeMemberFunction.typeParams = listOf(setElementTypeParam)
     removeMemberFunction.costExpression = costExpression
-    val removeFormalParamId = Identifier("element")
+    val removeFormalParamId = Identifier(NotInSource, "element")
     val removeFormalParam =
         FunctionFormalParameterSymbol(removeMemberFunction, removeFormalParamId, setElementTypeParam)
     removeMemberFunction.define(removeFormalParamId, removeFormalParam)
@@ -88,7 +88,7 @@ fun createToImmutableSetPlugin(
 ) {
     val plugin = ParameterizedMemberPluginSymbol(
         mutableSetType,
-        Identifier(CollectionMethods.ToImmutableSet.idStr),
+        Identifier(NotInSource, CollectionMethods.ToImmutableSet.idStr),
         DoubleParentArgInstantiation
     ) { t: Value, _: List<Value> ->
         (t as SetValue).evalToSet()
@@ -137,7 +137,7 @@ fun setCollectionType(
         setElementTypeParam
     )
 
-    val sizeId = Identifier(CollectionFields.Size.idStr)
+    val sizeId = Identifier(NotInSource, CollectionFields.Size.idStr)
     val sizeFieldSymbol = PlatformFieldSymbol(
         setType,
         sizeId,
@@ -215,7 +215,7 @@ fun mutableSetCollectionType(
         setType
     )
 
-    val sizeId = Identifier(CollectionFields.Size.idStr)
+    val sizeId = Identifier(NotInSource, CollectionFields.Size.idStr)
     val sizeFieldSymbol = PlatformFieldSymbol(
         mutableSetType,
         sizeId,

--- a/src/main/kotlin/org/shardscript/semantics/prelude/StaticPlugins.kt
+++ b/src/main/kotlin/org/shardscript/semantics/prelude/StaticPlugins.kt
@@ -40,11 +40,11 @@ fun createRangePlugin(
     rangePlugin.define(Lang.rangeTypeId, rangeTypeParam)
     rangePlugin.typeParams = listOf(rangeTypeParam)
 
-    val beginFormalParamId = Identifier("begin")
+    val beginFormalParamId = Identifier(NotInSource, "begin")
     val beginFormalParam = FunctionFormalParameterSymbol(rangePlugin, beginFormalParamId, intType)
     rangePlugin.define(beginFormalParamId, beginFormalParam)
 
-    val endFormalParamId = Identifier("end")
+    val endFormalParamId = Identifier(NotInSource, "end")
     val endFormalParam = FunctionFormalParameterSymbol(rangePlugin, endFormalParamId, intType)
     rangePlugin.define(endFormalParamId, endFormalParam)
     rangePlugin.formalParams = listOf(beginFormalParam, endFormalParam)
@@ -110,11 +110,11 @@ fun createRandomPlugin(
     randomPlugin.define(Lang.randomTypeId, randomTypeParam)
     randomPlugin.typeParams = listOf(randomTypeParam)
 
-    val beginFormalParamId = Identifier("offset")
+    val beginFormalParamId = Identifier(NotInSource, "offset")
     val beginFormalParam = FunctionFormalParameterSymbol(randomPlugin, beginFormalParamId, randomTypeParam)
     randomPlugin.define(beginFormalParamId, beginFormalParam)
 
-    val endFormalParamId = Identifier("limit")
+    val endFormalParamId = Identifier(NotInSource, "limit")
     val endFormalParam = FunctionFormalParameterSymbol(randomPlugin, endFormalParamId, randomTypeParam)
     randomPlugin.define(endFormalParamId, endFormalParam)
     randomPlugin.formalParams = listOf(beginFormalParam, endFormalParam)

--- a/src/main/kotlin/org/shardscript/semantics/prelude/StringOpMembers.kt
+++ b/src/main/kotlin/org/shardscript/semantics/prelude/StringOpMembers.kt
@@ -13,7 +13,7 @@ fun pluginToCharArray(
 ): ParameterizedMemberPluginSymbol {
     val res = ParameterizedMemberPluginSymbol(
         stringType,
-        Identifier(StringMethods.ToCharArray.idStr),
+        Identifier(NotInSource, StringMethods.ToCharArray.idStr),
         SingleParentArgInstantiation
     ) { t: Value, _: List<Value> ->
         (t as StringValue).evalToCharArray()
@@ -45,7 +45,7 @@ object StringEqualityOpMembers {
     ): ParameterizedMemberPluginSymbol {
         val res = ParameterizedMemberPluginSymbol(
             stringType,
-            Identifier(BinaryOperator.Add.idStr),
+            Identifier(NotInSource, BinaryOperator.Add.idStr),
             DualFinPluginInstantiation
         ) { t: Value, args: List<Value> ->
             (t as StringValue).evalAdd(args.first())
@@ -56,7 +56,7 @@ object StringEqualityOpMembers {
 
         val inputSubstitution = Substitution(stringType.typeParams, listOf(inputTypeArg))
         val inputType = inputSubstitution.apply(stringType)
-        val formalParamId = Identifier("other")
+        val formalParamId = Identifier(NotInSource, "other")
         val formalParam = FunctionFormalParameterSymbol(res, formalParamId, inputType)
         res.define(formalParamId, formalParam)
         res.formalParams = listOf(formalParam)
@@ -83,7 +83,7 @@ object StringEqualityOpMembers {
     ): ParameterizedMemberPluginSymbol {
         val res = ParameterizedMemberPluginSymbol(
             stringType,
-            Identifier(BinaryOperator.Equal.idStr),
+            Identifier(NotInSource, BinaryOperator.Equal.idStr),
             DualFinPluginInstantiation
         ) { t: Value, args: List<Value> ->
             (t as EqualityValue).evalEquals(args.first())
@@ -94,7 +94,7 @@ object StringEqualityOpMembers {
 
         val inputSubstitution = Substitution(stringType.typeParams, listOf(inputTypeArg))
         val inputType = inputSubstitution.apply(stringType)
-        val formalParamId = Identifier("other")
+        val formalParamId = Identifier(NotInSource, "other")
         val formalParam = FunctionFormalParameterSymbol(res, formalParamId, inputType)
         res.define(formalParamId, formalParam)
         res.formalParams = listOf(formalParam)
@@ -124,7 +124,7 @@ object StringEqualityOpMembers {
     ): ParameterizedMemberPluginSymbol {
         val res = ParameterizedMemberPluginSymbol(
             stringType,
-            Identifier(BinaryOperator.NotEqual.idStr),
+            Identifier(NotInSource, BinaryOperator.NotEqual.idStr),
             DualFinPluginInstantiation
         ) { t: Value, args: List<Value> ->
             (t as EqualityValue).evalNotEquals(args.first())
@@ -135,7 +135,7 @@ object StringEqualityOpMembers {
 
         val inputSubstitution = Substitution(stringType.typeParams, listOf(inputTypeArg))
         val inputType = inputSubstitution.apply(stringType)
-        val formalParamId = Identifier("other")
+        val formalParamId = Identifier(NotInSource, "other")
         val formalParam = FunctionFormalParameterSymbol(res, formalParamId, inputType)
         res.define(formalParamId, formalParam)
         res.formalParams = listOf(formalParam)

--- a/src/main/kotlin/org/shardscript/semantics/prelude/StringTypes.kt
+++ b/src/main/kotlin/org/shardscript/semantics/prelude/StringTypes.kt
@@ -25,13 +25,13 @@ fun stringType(
     }
 
     StringEqualityOpMembers.members(stringType, stringTypeParam, booleanType).forEach { (name, plugin) ->
-        stringType.define(Identifier(name), plugin)
+        stringType.define(Identifier(NotInSource, name), plugin)
     }
 
     val toCharArray = pluginToCharArray(stringType, stringTypeParam, charType, listType)
-    stringType.define(Identifier(StringMethods.ToCharArray.idStr), toCharArray)
+    stringType.define(Identifier(NotInSource, StringMethods.ToCharArray.idStr), toCharArray)
 
-    val sizeId = Identifier(CollectionFields.Size.idStr)
+    val sizeId = Identifier(NotInSource, CollectionFields.Size.idStr)
     val sizeFieldSymbol = PlatformFieldSymbol(
         stringType,
         sizeId,

--- a/src/main/kotlin/org/shardscript/semantics/prelude/ToStringMembers.kt
+++ b/src/main/kotlin/org/shardscript/semantics/prelude/ToStringMembers.kt
@@ -10,7 +10,7 @@ fun insertIntegerToStringMember(
 ) {
     val res = GroundMemberPluginSymbol(
         integerType,
-        Identifier(StringMethods.ToString.idStr),
+        Identifier(NotInSource, StringMethods.ToString.idStr),
     { t: Value, _: List<Value> ->
         (t as IntValue).evalToString()
     })
@@ -30,7 +30,7 @@ fun insertUnitToStringMember(
 ) {
     val res = GroundMemberPluginSymbol(
         unitType,
-        Identifier(StringMethods.ToString.idStr),
+        Identifier(NotInSource, StringMethods.ToString.idStr),
     { t: Value, _: List<Value> ->
         (t as UnitValue).evalToString()
     })
@@ -50,7 +50,7 @@ fun insertBooleanToStringMember(
 ) {
     val res = GroundMemberPluginSymbol(
         booleanType,
-        Identifier(StringMethods.ToString.idStr),
+        Identifier(NotInSource, StringMethods.ToString.idStr),
     { t: Value, _: List<Value> ->
         (t as BooleanValue).evalToString()
     })
@@ -70,7 +70,7 @@ fun insertDecimalToStringMember(
 ) {
     val res = ParameterizedMemberPluginSymbol(
         decimalType,
-        Identifier(StringMethods.ToString.idStr),
+        Identifier(NotInSource, StringMethods.ToString.idStr),
         SingleParentArgInstantiation,
     { t: Value, _: List<Value> ->
         (t as DecimalValue).evalToString()
@@ -91,7 +91,7 @@ fun insertStringToStringMember(
 ) {
     val res = ParameterizedMemberPluginSymbol(
         stringType,
-        Identifier(StringMethods.ToString.idStr),
+        Identifier(NotInSource, StringMethods.ToString.idStr),
         SingleParentArgInstantiation,
     { t: Value, _: List<Value> ->
         (t as StringValue).evalToString()
@@ -113,7 +113,7 @@ fun insertCharToStringMember(
 ) {
     val res = GroundMemberPluginSymbol(
         charType,
-        Identifier(StringMethods.ToString.idStr),
+        Identifier(NotInSource, StringMethods.ToString.idStr),
     { t: Value, _: List<Value> ->
         (t as CharValue).evalToString()
     })

--- a/src/main/kotlin/org/shardscript/semantics/visitors/PropagateTypesAstVisitor.kt
+++ b/src/main/kotlin/org/shardscript/semantics/visitors/PropagateTypesAstVisitor.kt
@@ -319,7 +319,7 @@ class PropagateTypesAstVisitor(
             if (ast.typeParams.isEmpty()) {
                 val groundFunctionSymbol = ast.scope as GroundFunctionSymbol
                 if (Lang.isUnitExactly(groundFunctionSymbol.returnType) && !Lang.isUnitExactly(ast.body.readType())) {
-                    val refAst = RefAst(Lang.unitId)
+                    val refAst = RefAst(NotInSource, Lang.unitId)
                     refAst.scope = ast.body.scope
                     refAst.accept(this)
                     ast.body.lines.add(refAst)
@@ -328,7 +328,7 @@ class PropagateTypesAstVisitor(
             } else {
                 val parameterizedFunctionSymbol = ast.scope as ParameterizedFunctionSymbol
                 if (Lang.isUnitExactly(parameterizedFunctionSymbol.returnType) && !Lang.isUnitExactly(ast.body.readType())) {
-                    val refAst = RefAst(Lang.unitId)
+                    val refAst = RefAst(NotInSource, Lang.unitId)
                     refAst.scope = ast.body.scope
                     refAst.accept(this)
                     ast.body.lines.add(refAst)

--- a/src/main/kotlin/org/shardscript/semantics/workflow/ProcessAst.kt
+++ b/src/main/kotlin/org/shardscript/semantics/workflow/ProcessAst.kt
@@ -90,7 +90,7 @@ fun processAstAllPhases(
     existingArtifacts.forEach { artifact ->
         registerImports(artifact.processedAst, userScopes.imports)
         artifact.userScopes.userRoot.symbolTable.toMap().forEach { entry ->
-            userScopes.userRoot.define(entry.key, entry.value)
+            userScopes.userRoot.define(Identifier(NotInSource, entry.key), entry.value)
         }
     }
 

--- a/src/test/kotlin/org/shardscript/acceptance/ImportErrorTests.kt
+++ b/src/test/kotlin/org/shardscript/acceptance/ImportErrorTests.kt
@@ -10,7 +10,7 @@ class ImportErrorTests {
     fun duplicateImportTest() {
         failTest(
             """
-            shard test.ids.errors
+            script test.ids.errors
             import test.imported
             import test.imported
             
@@ -25,7 +25,7 @@ class ImportErrorTests {
     fun ambiguousSymbolTest() {
         failTest(
             """
-            shard test.ids.errors
+            script test.ids.errors
             import test.imported
             import test.duplicates
             
@@ -40,7 +40,7 @@ class ImportErrorTests {
     fun deepImportTestTest() {
         failTest(
             """
-            shard test.ids.errors
+            script test.ids.errors
             import test.imported
             
             deepLeft(3, 4)

--- a/src/test/kotlin/org/shardscript/acceptance/ImportHappyTests.kt
+++ b/src/test/kotlin/org/shardscript/acceptance/ImportHappyTests.kt
@@ -7,7 +7,7 @@ class ImportHappyTests {
     fun basicImportTest() {
         splitTest(
             """
-            shard test.ids.happy
+            script test.ids.happy
             import test.imported
             
             importedFunction(3, 4)

--- a/src/test/kotlin/org/shardscript/acceptance/TestUtils.kt
+++ b/src/test/kotlin/org/shardscript/acceptance/TestUtils.kt
@@ -54,7 +54,7 @@ fun testEval(
     sourceStore.addArtifacts(
         listOf("test", "deep", "left"),
         """
-            shard test.deep.left
+            script test.deep.left
             
             def deepLeft(x: Int, y: Int): Int {
                 x * y
@@ -65,7 +65,7 @@ fun testEval(
     sourceStore.addArtifacts(
         listOf("test", "deep", "right"),
         """
-            shard test.deep.right
+            script test.deep.right
             
             def deepRight(x: Int, y: Int): Int {
                 x * y
@@ -76,7 +76,7 @@ fun testEval(
     sourceStore.addArtifacts(
         listOf("test", "imported"),
         """
-            shard test.imported
+            script test.imported
             
             import test.deep.left
             import test.deep.right
@@ -96,7 +96,7 @@ fun testEval(
     sourceStore.addArtifacts(
         listOf("test", "duplicates"),
         """
-            shard test.duplicates
+            script test.duplicates
             
             def duplicateFunction(x: Int, y: Int): Int {
                 x * y


### PR DESCRIPTION
Remove paths, symbol tables use String instead of Identifier, add source context to the constructor of Ast and Signifier.