### PR TITLE
V0.1.8

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = "moirai-lang"
-version = "0.1.7"
+version = "0.1.8"
 
 repositories {
     mavenCentral()

--- a/src/main/kotlin/moirai/semantics/core/TypeMechanics.kt
+++ b/src/main/kotlin/moirai/semantics/core/TypeMechanics.kt
@@ -364,20 +364,28 @@ internal fun checkTypes(
 
         expected is ConstantFin && actual is ConstantFin -> Unit
         expected is MaxCostExpression && actual is MaxCostExpression -> {
-            checkTypes(ctx, prelude, errors, expected.children, actual.children)
+            if (expected.children.size != actual.children.size) {
+                errors.add(ctx, TypeMismatch(toError(expected), toError(actual)))
+            } else {
+                checkTypes(ctx, prelude, errors, expected.children, actual.children)
+            }
         }
 
         expected is ProductCostExpression && actual is ProductCostExpression -> {
-            checkTypes(ctx, prelude, errors, expected.children, actual.children)
+            if (expected.children.size != actual.children.size) {
+                errors.add(ctx, TypeMismatch(toError(expected), toError(actual)))
+            } else {
+                checkTypes(ctx, prelude, errors, expected.children, actual.children)
+            }
         }
 
         expected is SumCostExpression && actual is SumCostExpression -> {
-            checkTypes(ctx, prelude, errors, expected.children, actual.children)
+            if (expected.children.size != actual.children.size) {
+                errors.add(ctx, TypeMismatch(toError(expected), toError(actual)))
+            } else {
+                checkTypes(ctx, prelude, errors, expected.children, actual.children)
+            }
         }
-
-        // We seem to hit this case during string interpolation, and the actual resolution happens during
-        // the CostExpressionAstVisitor phase
-        expected is CostExpression && actual is CostExpression -> Unit
 
         else -> {
             val expectedPath = getQualifiedName(expected)

--- a/src/main/kotlin/moirai/semantics/core/TypeMechanics.kt
+++ b/src/main/kotlin/moirai/semantics/core/TypeMechanics.kt
@@ -367,7 +367,9 @@ internal fun checkTypes(
             if (expected.children.size != actual.children.size) {
                 errors.add(ctx, TypeMismatch(toError(expected), toError(actual)))
             } else {
-                checkTypes(ctx, prelude, errors, expected.children, actual.children)
+                val expectedChildrenCanonical = sortCanonical(expected.children)
+                val actualChildrenCanonical = sortCanonical(expected.children)
+                checkTypes(ctx, prelude, errors, expectedChildrenCanonical, actualChildrenCanonical)
             }
         }
 
@@ -375,7 +377,9 @@ internal fun checkTypes(
             if (expected.children.size != actual.children.size) {
                 errors.add(ctx, TypeMismatch(toError(expected), toError(actual)))
             } else {
-                checkTypes(ctx, prelude, errors, expected.children, actual.children)
+                val expectedChildrenCanonical = sortCanonical(expected.children)
+                val actualChildrenCanonical = sortCanonical(expected.children)
+                checkTypes(ctx, prelude, errors, expectedChildrenCanonical, actualChildrenCanonical)
             }
         }
 
@@ -383,7 +387,9 @@ internal fun checkTypes(
             if (expected.children.size != actual.children.size) {
                 errors.add(ctx, TypeMismatch(toError(expected), toError(actual)))
             } else {
-                checkTypes(ctx, prelude, errors, expected.children, actual.children)
+                val expectedChildrenCanonical = sortCanonical(expected.children)
+                val actualChildrenCanonical = sortCanonical(expected.children)
+                checkTypes(ctx, prelude, errors, expectedChildrenCanonical, actualChildrenCanonical)
             }
         }
 
@@ -396,6 +402,18 @@ internal fun checkTypes(
         }
     }
 }
+
+private fun sortCanonical(costExpressions: List<CostExpression>): List<CostExpression> {
+    val res: MutableList<CostExpression> = mutableListOf()
+    res.addAll(costExpressions.filterIsInstance<MaxCostExpression>())
+    res.addAll(costExpressions.filterIsInstance<ProductCostExpression>())
+    res.addAll(costExpressions.filterIsInstance<SumCostExpression>())
+    res.addAll(costExpressions.filterIsInstance<FinTypeParameter>().sortedBy { it.qualifiedName })
+    res.addAll(costExpressions.filterIsInstance<Fin>().sortedBy { it.magnitude })
+    res.addAll(costExpressions.filterIsInstance<ConstantFin>())
+    return res
+}
+
 
 internal fun checkTypes(
     ctx: SourceContext,

--- a/src/test/kotlin/moirai/acceptance/FunctionHappyTests.kt
+++ b/src/test/kotlin/moirai/acceptance/FunctionHappyTests.kt
@@ -96,4 +96,23 @@ class FunctionHappyTests {
             """.trimIndent()
         )
     }
+
+    @Test
+    fun costExprLiteralReturnTypeCanonicalTest() {
+        splitTest(
+            """
+                def maxList<T, M: Fin, N: Fin>(listM: List<T, M>, listN: List<T, N> ): List<T, Max(N, M)> {
+                    if (listM.size > listN.size) {
+                        listM
+                    } else {
+                        listN
+                    }
+                }
+                
+                maxList(List(1, 2, 3), List(1, 2, 3, 4, 5))
+                ^^^^^
+                List(1, 2, 3, 4, 5)
+            """.trimIndent()
+        )
+    }
 }


### PR DESCRIPTION
Use canonical ordering when comparing cost expressions in a type.