### PR TITLE
Sort all children of all Mul, Max, Sum cost expressions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = "moirai-lang"
-version = "0.1.8"
+version = "0.1.9"
 
 repositories {
     mavenCentral()

--- a/src/main/kotlin/moirai/semantics/core/CostExpression.kt
+++ b/src/main/kotlin/moirai/semantics/core/CostExpression.kt
@@ -21,6 +21,17 @@ internal enum class CostOperator(val idStr: String) {
     Max("Max")
 }
 
+internal fun sortCanonical(costExpressions: List<CostExpression>): List<CostExpression> {
+    val res: MutableList<CostExpression> = mutableListOf()
+    res.addAll(costExpressions.filterIsInstance<MaxCostExpression>())
+    res.addAll(costExpressions.filterIsInstance<ProductCostExpression>())
+    res.addAll(costExpressions.filterIsInstance<SumCostExpression>())
+    res.addAll(costExpressions.filterIsInstance<FinTypeParameter>().sortedBy { it.qualifiedName })
+    res.addAll(costExpressions.filterIsInstance<Fin>().sortedBy { it.magnitude })
+    res.addAll(costExpressions.filterIsInstance<ConstantFin>())
+    return res
+}
+
 internal class EvalCostExpressionVisitor(val architecture: Architecture): CostExpressionVisitor<Long> {
     init {
         if(architecture.costUpperLimit > sqrt(Long.MAX_VALUE.toDouble()).toLong() - 2) {

--- a/src/main/kotlin/moirai/semantics/core/Type.kt
+++ b/src/main/kotlin/moirai/semantics/core/Type.kt
@@ -41,19 +41,25 @@ internal data object ConstantFin : CostExpression, Type {
     }
 }
 
-internal class SumCostExpression(val children: List<CostExpression>) : CostExpression {
+internal class SumCostExpression(args: List<CostExpression>) : CostExpression {
+    val children: List<CostExpression> = sortCanonical(args)
+
     override fun <R> accept(visitor: CostExpressionVisitor<R>): R {
         return visitor.visit(this)
     }
 }
 
-internal class ProductCostExpression(val children: List<CostExpression>) : CostExpression {
+internal class ProductCostExpression(args: List<CostExpression>) : CostExpression {
+    val children: List<CostExpression> = sortCanonical(args)
+
     override fun <R> accept(visitor: CostExpressionVisitor<R>): R {
         return visitor.visit(this)
     }
 }
 
-internal class MaxCostExpression(val children: List<CostExpression>) : CostExpression {
+internal class MaxCostExpression(args: List<CostExpression>) : CostExpression {
+    val children: List<CostExpression> = sortCanonical(args)
+
     override fun <R> accept(visitor: CostExpressionVisitor<R>): R {
         return visitor.visit(this)
     }

--- a/src/main/kotlin/moirai/semantics/core/TypeMechanics.kt
+++ b/src/main/kotlin/moirai/semantics/core/TypeMechanics.kt
@@ -367,9 +367,7 @@ internal fun checkTypes(
             if (expected.children.size != actual.children.size) {
                 errors.add(ctx, TypeMismatch(toError(expected), toError(actual)))
             } else {
-                val expectedChildrenCanonical = sortCanonical(expected.children)
-                val actualChildrenCanonical = sortCanonical(expected.children)
-                checkTypes(ctx, prelude, errors, expectedChildrenCanonical, actualChildrenCanonical)
+                checkTypes(ctx, prelude, errors, expected.children, actual.children)
             }
         }
 
@@ -377,9 +375,7 @@ internal fun checkTypes(
             if (expected.children.size != actual.children.size) {
                 errors.add(ctx, TypeMismatch(toError(expected), toError(actual)))
             } else {
-                val expectedChildrenCanonical = sortCanonical(expected.children)
-                val actualChildrenCanonical = sortCanonical(expected.children)
-                checkTypes(ctx, prelude, errors, expectedChildrenCanonical, actualChildrenCanonical)
+                checkTypes(ctx, prelude, errors, expected.children, actual.children)
             }
         }
 
@@ -387,9 +383,7 @@ internal fun checkTypes(
             if (expected.children.size != actual.children.size) {
                 errors.add(ctx, TypeMismatch(toError(expected), toError(actual)))
             } else {
-                val expectedChildrenCanonical = sortCanonical(expected.children)
-                val actualChildrenCanonical = sortCanonical(expected.children)
-                checkTypes(ctx, prelude, errors, expectedChildrenCanonical, actualChildrenCanonical)
+                checkTypes(ctx, prelude, errors, expected.children, actual.children)
             }
         }
 
@@ -402,18 +396,6 @@ internal fun checkTypes(
         }
     }
 }
-
-private fun sortCanonical(costExpressions: List<CostExpression>): List<CostExpression> {
-    val res: MutableList<CostExpression> = mutableListOf()
-    res.addAll(costExpressions.filterIsInstance<MaxCostExpression>())
-    res.addAll(costExpressions.filterIsInstance<ProductCostExpression>())
-    res.addAll(costExpressions.filterIsInstance<SumCostExpression>())
-    res.addAll(costExpressions.filterIsInstance<FinTypeParameter>().sortedBy { it.qualifiedName })
-    res.addAll(costExpressions.filterIsInstance<Fin>().sortedBy { it.magnitude })
-    res.addAll(costExpressions.filterIsInstance<ConstantFin>())
-    return res
-}
-
 
 internal fun checkTypes(
     ctx: SourceContext,


### PR DESCRIPTION
Fix a bug where expected and actual cost expressions were not being compared properly. Blanket convert all child arguments of all complex cost expressions to canonical form.