### PR TITLE
Add eval function that accepts a CompilerFrontend

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = "org.moirai-lang"
-version = "0.2.7"
+version = "0.2.8"
 
 repositories {
     mavenCentral()

--- a/src/main/kotlin/moirai/composition/CompilerFrontend.kt
+++ b/src/main/kotlin/moirai/composition/CompilerFrontend.kt
@@ -6,7 +6,7 @@ import moirai.transport.TransportAst
 import moirai.transport.convertToAst
 
 class CompilerFrontend(
-    private val architecture: Architecture,
+    val architecture: Architecture,
     private val sourceStore: SourceStore,
     pluginSource: PluginSource = NoPluginSource
 ) {

--- a/src/main/kotlin/moirai/composition/ProcessPlugins.kt
+++ b/src/main/kotlin/moirai/composition/ProcessPlugins.kt
@@ -1,10 +1,23 @@
 package moirai.composition
 
+import moirai.eval.UserPlugin
 import moirai.semantics.core.*
 import moirai.semantics.prelude.Lang
 import moirai.semantics.visitors.bindFormals
 import moirai.semantics.visitors.qualifiedName
 import org.antlr.v4.runtime.tree.ParseTreeWalker
+
+internal fun pluginMap(userPlugins: List<UserPlugin>): Map<String, UserPlugin> {
+    val userPluginMap: MutableMap<String, UserPlugin> = mutableMapOf()
+    userPlugins.forEach {
+        if (!userPluginMap.containsKey(it.key)) {
+            userPluginMap[it.key] = it
+        } else {
+            langThrow(NotInSource, PluginAlreadyExists(it.key))
+        }
+    }
+    return userPluginMap.toMap()
+}
 
 internal fun parsePlugins(fileName: String, pluginSource: String, errors: LanguageErrors): List<PluginDefLiteral> {
     val parser = createParser(pluginSource)


### PR DESCRIPTION
The CompilerFrontend object has a single internal method that has a private return type. Existing frontends should work with the eval function in the case where this function may be called.